### PR TITLE
Vctr 88 log10.h gcem log10 doesn t compile

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -145,7 +145,7 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: (Windows) Install dependencies
-        run: choco install llvm --version 15.0.4 -y && choco install ninja -y && pip3 install conan
+        run: choco install ninja -y && pip3 install conan
         if: runner.os == 'Windows'
 
       - name: (Windows) Configure dev environment variables

--- a/include/vctr/Miscellaneous/Config.h
+++ b/include/vctr/Miscellaneous/Config.h
@@ -108,12 +108,12 @@
 #endif
 #endif
 
-/** Define this to 1 in case gcem (https://github.com/kthohr/gcem) is available.
+/** Define this to 1 in case gcem (https://github.com/kthohr/gcem) is available. The minimum required version is gcem 1.16.0.
 
-    If not defined, it will decide whether to use IPP or not depending on the result of __has_include (<gcem/gcem.hpp>)
+    If not defined, it will decide whether to use IPP or not depending on the result of __has_include (<gcem.hpp>)
  */
 #ifndef VCTR_USE_GCEM
-#if __has_include(<gcem/gcem.hpp>)
+#if __has_include(<gcem.hpp>)
 #define VCTR_USE_GCEM 1
 #else
 #define VCTR_USE_GCEM 0

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -92,7 +92,12 @@
 #endif
 
 #if VCTR_USE_GCEM
-#include <gcem/gcem.hpp>
+#include <gcem.hpp>
+
+#if ((GCEM_VERSION_MAJOR < 1) || (GCEM_VERSION_MAJOR == 1 && GCEM_VERSION_MINOR < 16))
+#error "VCTR needs gcem version 1.16.0 or greater"
+#endif
+
 #endif
 
 //==============================================================================


### PR DESCRIPTION
This should fix the errors you were encountering. `gcem::log10` was introduced with version 1.16.0, these changes will warn if the installed version is below that.