### PR TITLE
Vctr 30 implement assignment operators

### DIFF
--- a/include/vctr/Containers/Array.h
+++ b/include/vctr/Containers/Array.h
@@ -166,11 +166,30 @@ public:
         Vctr::assignExpressionTemplate (std::forward<Expression> (e));
     }
 
-    /** Copies the data of the source container to this Array. */
+    //==============================================================================
+    // Operators
+    //==============================================================================
+    /** Copies or moves the data of the source container to this Array. You have to ensure that the source size matches. */
     template <has::sizeAndDataWithElementType<ElementType> Container>
-    constexpr Array& operator= (const Container& containerToCopyDataFrom)
+    constexpr Array& operator= (Container&& containerToCopyDataFrom)
     {
-        Vctr::copyFrom (containerToCopyDataFrom.data(), containerToCopyDataFrom.size());
+        if constexpr (Vctr::template shouldMoveFromOtherContainer<Container>)
+        {
+            VCTR_ASSERT (containerToCopyDataFrom.size() == Vctr::size());
+            std::copy (std::make_move_iterator (containerToCopyDataFrom.begin()), std::make_move_iterator (containerToCopyDataFrom.end()), Vctr::storage.begin());
+        }
+        else
+        {
+            Vctr::copyFrom (containerToCopyDataFrom.data(), containerToCopyDataFrom.size());
+        }
+
+        return *this;
+    }
+
+    /** Assigns elements from the initializer list to this Array. You have to ensure that the source size matches. */
+    constexpr Array& operator= (std::initializer_list<ElementType> elementsToAssign)
+    {
+        Vctr::assign (std::move (elementsToAssign));
         return *this;
     }
 

--- a/include/vctr/Containers/Span.h
+++ b/include/vctr/Containers/Span.h
@@ -103,11 +103,30 @@ public:
         VCTR_ASSERT (extent == containerToView.size() || extent == std::dynamic_extent);
     }
 
-    /** Copies the data of the source container to the memory this span refers to. */
+    //==============================================================================
+    // Operators
+    //==============================================================================
+    /** Copies or moves the data of the source container to this Span. You have to ensure that the source size matches. */
     template <has::sizeAndDataWithElementType<ElementType> Container>
-    constexpr Span& operator= (const Container& containerToCopyDataFrom)
+    constexpr Span& operator= (Container&& containerToCopyDataFrom)
     {
-        Vctr::copyFrom (containerToCopyDataFrom.data(), containerToCopyDataFrom.size());
+        if constexpr (Vctr::template shouldMoveFromOtherContainer<Container>)
+        {
+            VCTR_ASSERT (containerToCopyDataFrom.size() == Vctr::size());
+            std::copy (std::make_move_iterator (containerToCopyDataFrom.begin()), std::make_move_iterator (containerToCopyDataFrom.end()), Vctr::storage.begin());
+        }
+        else
+        {
+            Vctr::copyFrom (containerToCopyDataFrom.data(), containerToCopyDataFrom.size());
+        }
+
+        return *this;
+    }
+
+    /** Assigns elements from the initializer list to this Span. You have to ensure that the source size matches. */
+    constexpr Span& operator= (std::initializer_list<ElementType> elementsToAssign)
+    {
+        Vctr::assign (std::move (elementsToAssign));
         return *this;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources (vctr_test PRIVATE
         TestCases/ElementAccessFunctions.cpp
         TestCases/FindingAndManipulatingElements.cpp
         TestCases/SpanConstructors.cpp
+        TestCases/SpanMemberFunctions.cpp
         TestCases/VctrBaseMemberFunctions.cpp
         TestCases/VectorMemberFunctions.cpp
         TestCases/VectorConstructors.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries (vctr_test PRIVATE vctr vctr_test_utils Catch2::Catch2 gce
 
 target_sources (vctr_test PRIVATE
         TestCases/ArrayConstructors.cpp
+        TestCases/ArrayMemberFunctions.cpp
         TestCases/ConversionOperators.cpp
         TestCases/ElementAccessFunctions.cpp
         TestCases/FindingAndManipulatingElements.cpp

--- a/test/TestCases/ArrayMemberFunctions.cpp
+++ b/test/TestCases/ArrayMemberFunctions.cpp
@@ -1,0 +1,59 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+TEST_CASE ("Assignment operator", "[ArrayMemberFunctions]")
+{
+    vctr::Array<int, 3> ints;
+
+    // Assignment from an initializer list
+    ints = { 1, 2, 3 };
+    REQUIRE_THAT (ints, vctr::Equals ({ 1, 2, 3 }));
+
+    // Assignment from a different container type
+    std::vector v { 4, 5, 6 };
+    ints = v;
+    REQUIRE_THAT (ints, vctr::Equals ({ 4, 5, 6 }));
+
+    // Assignment from another Array
+    vctr::Array a = { 7, 8, 9 };
+    ints = a;
+    REQUIRE_THAT (ints, vctr::Equals ({ 7, 8, 9 }));
+
+    // Move-assignment from another Array
+    vctr::Array a2 = { 10, 11, 12 };
+    ints = std::move (a2);
+    REQUIRE_THAT (ints, vctr::Equals ({ 10, 11, 12 }));
+
+    vctr::Array<std::string, 3> strings;
+
+    // Move-assignment from the underlying container type
+    std::array<std::string, 3> ma = { "foo", "bar", "baz" };
+    strings = std::move (ma);
+    REQUIRE_THAT (strings, vctr::Equals ({ "foo", "bar", "baz" }));
+
+    // Move-assignment from a different container type
+    vctr::Vector<std::string> mv = { "I", "love", "sonible" };
+    strings = std::move (mv);
+    REQUIRE_THAT (strings, vctr::Equals ({ "I", "love", "sonible" }));
+}

--- a/test/TestCases/SpanMemberFunctions.cpp
+++ b/test/TestCases/SpanMemberFunctions.cpp
@@ -1,0 +1,46 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+TEST_CASE ("Assignment operator", "[SpanMemberFunctions]")
+{
+    std::array<int, 3> intStorage { 0 };
+    vctr::Span ints (intStorage);
+
+    // Assignment from an initializer list
+    ints = { 1, 2, 3 };
+    REQUIRE_THAT (ints, vctr::Equals ({ 1, 2, 3 }));
+
+    // Assignment from a Vector
+    vctr::Vector a = { 7, 8, 9 };
+    ints = a;
+    REQUIRE_THAT (ints, vctr::Equals ({ 7, 8, 9 }));
+
+    std::array<std::string, 3> stringStorage;
+    vctr::Span strings (stringStorage);
+
+    // Move-assignment from a different container type
+    vctr::Vector<std::string> mv = { "I", "love", "sonible" };
+    strings = std::move (mv);
+    REQUIRE_THAT (strings, vctr::Equals ({ "I", "love", "sonible" }));
+}

--- a/test/TestCases/VectorMemberFunctions.cpp
+++ b/test/TestCases/VectorMemberFunctions.cpp
@@ -22,9 +22,43 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-#include <catch2/matchers/catch_matchers_string.hpp>
-
 #include <list>
+
+TEST_CASE ("Assignment operator", "[VectorMemberFunctions]")
+{
+    vctr::Vector<int> ints;
+
+    // Assignment from an initializer list
+    ints = { 1, 2, 3, 4 };
+    REQUIRE_THAT (ints, vctr::Equals ({ 1, 2, 3, 4 }));
+
+    // Assignment from a different container type
+    std::array a { 5, 6, 7, 8, 9 };
+    ints = a;
+    REQUIRE_THAT (ints, vctr::Equals ({ 5, 6, 7, 8, 9 }));
+
+    // Assignment from another Vector
+    vctr::Vector v = { 10, 11, 12 };
+    ints = v;
+    REQUIRE_THAT (ints, vctr::Equals ({ 10, 11, 12 }));
+
+    // Move-assignment from another Vector
+    vctr::Vector v2 = { 13, 14, 15, 16 };
+    ints = std::move (v2);
+    REQUIRE_THAT (ints, vctr::Equals ({ 13, 14, 15, 16 }));
+
+    vctr::Vector<std::string> strings;
+
+    // Move-assignment from a different container type
+    std::array<std::string, 3> ma = { "foo", "bar", "baz" };
+    strings = std::move (ma);
+    REQUIRE_THAT (strings, vctr::Equals ({ "foo", "bar", "baz" }));
+
+    // Move-assignment from the underlying container type
+    std::vector<std::string> mv = { "I", "love", "sonible", "!" };
+    strings = std::move (mv);
+    REQUIRE_THAT (strings, vctr::Equals ({ "I", "love", "sonible", "!" }));
+}
 
 TEST_CASE ("capacity, shrink_to_fit, reserve, clear", "[VectorMemberFunctions]")
 {

--- a/test/include/vctr_test_utils/vctr_test_common.h
+++ b/test/include/vctr_test_utils/vctr_test_common.h
@@ -216,5 +216,5 @@ struct Neon
 #define VCTR_TEST_DEFINES_WITH_TRAILING_ZERO_IN_RANGE(start, end, testVectorSize) VCTR_TEST_DEFINES_BASE (testVectorSize, start, end, false, true)
 
 #include <vctr_test_utils/vctr_catch_matchers.h>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 #include <catch2/catch_template_test_macros.hpp>


### PR DESCRIPTION
I tried to implement the assignment operators in a way that a move is preferred in case the source is moved or passed by value, while defaulting back to a plain element copy otherwise