### PR TITLE
Vctr 54 implement pow

### DIFF
--- a/include/vctr/Containers/VctrBase.tpp
+++ b/include/vctr/Containers/VctrBase.tpp
@@ -74,7 +74,7 @@ template <class ElementType, class StorageType, size_t extent, class StorageInfo
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator/= (value_type c)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::DivideVecBySingle<extent, decltype (self)> (self, c));
+    assignExpressionTemplate (Expressions::DivideVecBySingle<extent, decltype (self)> (c, self));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
@@ -112,7 +112,7 @@ template <class ElementType, class StorageType, size_t extent, class StorageInfo
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator-= (value_type c)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::SubtractSingleFromVec<extent, decltype (self)> (self, c));
+    assignExpressionTemplate (Expressions::SubtractSingleFromVec<extent, decltype (self)> (c, self));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>

--- a/include/vctr/Expressions/Core/Add.h
+++ b/include/vctr/Expressions/Core/Add.h
@@ -29,39 +29,13 @@ template <size_t extent, class SrcAType, class SrcBType>
 class AddVectors : ExpressionTemplateBase
 {
 public:
-    using value_type = std::common_type_t<typename std::remove_cvref_t<SrcAType>::value_type, typename std::remove_cvref_t<SrcBType>::value_type>;
+    using value_type = std::common_type_t<ValueType<SrcAType>, ValueType<SrcBType>>;
 
-    using Expression = ExpressionTypes<value_type, SrcAType, SrcBType>;
-
-    template <class SrcA, class SrcB>
-    constexpr AddVectors (SrcA&& a, SrcB&& b)
-        : srcA (std::forward<SrcA> (a)),
-          srcB (std::forward<SrcB> (b)),
-          storageInfo (srcA.getStorageInfo(), srcB.getStorageInfo())
-    {}
-
-    constexpr const auto& getStorageInfo() const { return storageInfo; }
-
-    constexpr size_t size() const { return srcA.size(); }
+    VCTR_COMMON_BINARY_VEC_VEC_EXPRESSION_MEMBERS (AddVectors, srcA, srcB)
 
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
         return srcA[i] + srcB[i];
-    }
-
-    constexpr bool isNotAliased (const void* dst) const
-    {
-        if constexpr (is::expression<SrcAType> && is::anyVctr<SrcBType>)
-        {
-            return dst != srcB.data();
-        }
-
-        if constexpr (is::anyVctr<SrcAType> && is::expression<SrcBType>)
-        {
-            return dst != srcA.data();
-        }
-
-        return true;
     }
 
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
@@ -99,15 +73,6 @@ public:
     {
         return Expression::SSE::add (srcA.getSSE (i), srcB.getSSE (i));
     }
-
-private:
-    SrcAType srcA;
-    SrcBType srcB;
-
-    using SrcAStorageInfoType = std::remove_cvref_t<std::invoke_result_t<decltype (&std::remove_cvref_t<SrcAType>::getStorageInfo), SrcAType>>;
-    using SrcBStorageInfoType = std::remove_cvref_t<std::invoke_result_t<decltype (&std::remove_cvref_t<SrcBType>::getStorageInfo), SrcBType>>;
-
-    const CombinedStorageInfo<SrcAStorageInfoType, SrcBStorageInfoType> storageInfo;
 };
 
 //==============================================================================
@@ -118,29 +83,11 @@ class AddSingleToVec : ExpressionTemplateBase
 public:
     using value_type = ValueType<SrcType>;
 
-    using Expression = ExpressionTypes<value_type, SrcType>;
-
-    template <class Src>
-    constexpr AddSingleToVec (typename Expression::CommonSrcElement::Type a, Src&& b)
-        : src (std::forward<Src> (b)),
-          single (a),
-          asSSE (Expression::SSE::broadcast (a)),
-          asNeon (Expression::Neon::broadcast (a))
-    {
-    }
-
-    constexpr const auto& getStorageInfo() const { return src.getStorageInfo(); }
-
-    constexpr size_t size() const { return src.size(); }
+    VCTR_COMMON_BINARY_SINGLE_VEC_EXPRESSION_MEMBERS (AddSingleToVec, src, single)
 
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
         return single + src[i];
-    }
-
-    constexpr bool isNotAliased (const void* other) const
-    {
-        return src.isNotAliased (other);
     }
 
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
@@ -162,28 +109,21 @@ public:
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
     {
-        return Expression::AVX::add (Expression::AVX::fromSSE (asSSE, asSSE), src.getAVX (i));
+        return Expression::AVX::add (Expression::AVX::fromSSE (singleAsSSE, singleAsSSE), src.getAVX (i));
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx2") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isInt)
     {
-        return Expression::AVX::add (Expression::AVX::fromSSE (asSSE, asSSE), src.getAVX (i));
+        return Expression::AVX::add (Expression::AVX::fromSSE (singleAsSSE, singleAsSSE), src.getAVX (i));
     }
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
     requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame)
     {
-        return Expression::SSE::add (asSSE, src.getSSE (i));
+        return Expression::SSE::add (singleAsSSE, src.getSSE (i));
     }
-
-private:
-    SrcType src;
-
-    const typename Expression::CommonSrcElement::Type single;
-    const typename Expression::SSESrc asSSE;
-    const typename Expression::NeonSrc asNeon;
 };
 
 } // namespace vctr::Expressions

--- a/include/vctr/Expressions/Exp/Pow.h
+++ b/include/vctr/Expressions/Exp/Pow.h
@@ -23,11 +23,147 @@
 namespace vctr::Expressions
 {
 
+template <size_t extent, class SrcAType, class SrcBType>
+class PowVectors : ExpressionTemplateBase
+{
+public:
+    using CommonType = std::common_type_t<ValueType<SrcAType>, ValueType<SrcBType>>;
+    using value_type = std::conditional_t<std::integral<CommonType>, double, CommonType>;
+
+    VCTR_COMMON_BINARY_VEC_VEC_EXPRESSION_MEMBERS (PowVectors, srcBase, srcExp)
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+#if VCTR_USE_GCEM
+        if constexpr (! is::complexNumber<value_type>)
+        {
+            if (std::is_constant_evaluated())
+                return gcem::pow (srcBase[i], srcExp[i]);
+        }
+#endif
+
+        return std::pow (srcBase[i], srcExp[i]);
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForAccelerateRealFloatBinaryVectorOp<SrcAType, SrcBType, CommonType, detail::dontPreferIfIppAndAccelerateAreAvailable>
+    {
+        Expression::Accelerate::pow (srcBase.evalNextVectorOpInExpressionChain (dst), srcExp.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
+        return dst;
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealOrComplexComplexFloatBinaryVectorOp<SrcAType, SrcBType, CommonType, detail::preferIfIppAndAccelerateAreAvailable>
+    {
+        Expression::IPP::pow (srcBase.evalNextVectorOpInExpressionChain (dst), srcExp.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
+        return dst;
+    }
+
+    //==============================================================================
+    // Apple specific SIMD Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
+    requires platformApple && archX64 && has::getSSE<SrcAType> && has::getSSE<SrcBType> && std::same_as<float, value_type>
+    {
+        return SSERegister<value_type> { vpowf (srcBase.getSSE (i).value, srcExp.getSSE (i).value) };
+    }
+
+    NeonRegister<value_type> getNeon (size_t i) const
+    requires platformApple && archARM && has::getNeon<SrcAType> && has::getNeon<SrcBType> && std::same_as<float, value_type>
+    {
+        return NeonRegister<value_type> { vpowf (srcBase.getNeon (i).value, srcExp.getNeon (i).value) };
+    }
+};
+
+template <size_t extent, class SrcType>
+class PowSingleExponent : ExpressionTemplateBase
+{
+public:
+    using value_type = std::conditional_t<std::is_integral_v<ValueType<SrcType>>, double, ValueType<SrcType>>;
+
+    VCTR_COMMON_BINARY_SINGLE_VEC_EXPRESSION_MEMBERS (PowSingleExponent, base, exp)
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+#if VCTR_USE_GCEM
+        if constexpr (! is::complexNumber<value_type>)
+        {
+            if (std::is_constant_evaluated())
+                return gcem::pow (base[i], exp);
+        }
+#endif
+
+        return std::pow (base[i], exp);
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealOrComplexFloatVectorOp<SrcType, ValueType<SrcType>>
+    {
+        Expression::IPP::pow (base.evalNextVectorOpInExpressionChain (dst), exp, dst, sizeToInt (size()));
+        return dst;
+    }
+};
+
+template <size_t extent, class SrcType>
+class PowSingleBase : ExpressionTemplateBase
+{
+public:
+    using value_type = std::conditional_t<std::is_integral_v<ValueType<SrcType>>, double, ValueType<SrcType>>;
+
+    VCTR_COMMON_BINARY_SINGLE_VEC_EXPRESSION_MEMBERS (PowSingleBase, exp, base)
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+#if VCTR_USE_GCEM
+        if constexpr (! is::complexNumber<value_type>)
+        {
+            if (std::is_constant_evaluated())
+                return gcem::pow (base, exp[i]);
+        }
+#endif
+
+        return std::pow (base, exp[i]);
+    }
+};
+
+template <size_t extent, class SrcType, is::constant ConstantType>
+class PowConstantExponent : ExpressionTemplateBase
+{
+public:
+    using value_type = std::conditional_t<std::is_integral_v<ValueType<SrcType>>, double, ValueType<SrcType>>;
+
+    static constexpr value_type exp = ConstantType::value;
+
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (PowConstantExponent)
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+#if VCTR_USE_GCEM
+        if constexpr (! is::complexNumber<value_type>)
+        {
+            if (std::is_constant_evaluated())
+                return gcem::pow (src[i], exp);
+        }
+#endif
+
+        return std::pow (src[i], exp);
+    }
+    
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealOrComplexFloatVectorOp<SrcType, ValueType<SrcType>>
+    {
+        Expression::IPP::pow (src.evalNextVectorOpInExpressionChain (dst), exp, dst, sizeToInt (size()));
+        return dst;
+    }
+
+private:
+    SrcType src;
+};
+
 template <size_t extent, class SrcType, is::constant ConstantType>
 class PowConstantBase : ExpressionTemplateBase
 {
 public:
-    using value_type = ValueType<SrcType>;
+    using value_type = std::conditional_t<std::is_integral_v<ValueType<SrcType>>, double, ValueType<SrcType>>;
 
     static constexpr value_type base = ConstantType::value;
 
@@ -36,8 +172,11 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
 #if VCTR_USE_GCEM
-        if (std::is_constant_evaluated())
-            return gcem::pow (base, src[i]);
+        if constexpr (! is::complexNumber<value_type>)
+        {
+            if (std::is_constant_evaluated())
+                return gcem::pow (base, src[i]);
+        }
 #endif
 
         return std::pow (base, src[i]);
@@ -46,9 +185,12 @@ public:
     //==============================================================================
     // Platform Vector Operation Implementation
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
-    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type>
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, ValueType<SrcType>> ||
+             is::suitableForIppRealFloatVectorOp<SrcType, ValueType<SrcType>>
     {
-        // Todo: Quick workaround. Optimise it – maybe based on e.g. exp2 (log2 (base) * src)
+        // Todo: Quick workaround to use this in the context of chained accelerated operations.
+        //   This is useful to speed up decibel calculation. We should optimise it – maybe based
+        //   on chaining e.g. exp2 (log2 (base) * src)
         const auto s = size();
         const auto* x = src.evalNextVectorOpInExpressionChain (dst);
 
@@ -67,11 +209,57 @@ private:
 namespace vctr
 {
 
-/** Evaluates base raised to the power of the source vector.
+/** Returns an expression that raises the elements in bases element-wise to the power of the elements in exponents.
+
+    @ingroup Expressions
+ */
+    template <is::anyVctrOrExpression SrcBaseType, is::anyVctrOrExpression SrcExpType>
+    constexpr auto pow (SrcBaseType&& bases, SrcExpType&& exponents)
+{
+    assertCommonSize (bases, exponents);
+    constexpr auto extent = getCommonExtent<SrcBaseType, SrcExpType>();
+
+    return Expressions::PowVectors<extent, SrcBaseType, SrcExpType> (std::forward<SrcBaseType> (bases), std::forward<SrcExpType> (exponents));
+}
+
+/** Returns an expression that raises the base value base to the power of the elements in exponents.
+
+    @ingroup Expressions
+ */
+template <is::anyVctrOrExpression Src>
+constexpr auto pow (typename std::remove_cvref_t<Src>::value_type base, Src&& exponents)
+{
+    return Expressions::PowSingleBase<extentOf<Src>, Src> (base, exponents);
+}
+
+/** Returns an expression that raises the elements in bases to the power of the exponent value.
+
+    In case you want to raise the elements to the power of 2 or 3, better use the square or cube
+    expression.
+
+    @ingroup Expressions
+
+    @see square
+    @see cube
+ */
+template <is::anyVctrOrExpression Src>
+constexpr auto pow (Src&& bases, typename std::remove_cvref_t<Src>::value_type exponent)
+{
+    return Expressions::PowSingleExponent<extentOf<Src>, Src> (exponent, bases);
+}
+
+/** Evaluates base raised to the power of the source elements.
 
     @ingroup Expressions
  */
 template <auto base>
 constexpr inline ExpressionChainBuilder<Expressions::PowConstantBase, Constant<base>> powConstantBase;
+
+/** Evaluates the source elements raised to the power of exponent.
+
+    @ingroup Expressions
+ */
+template <auto exponent>
+constexpr inline ExpressionChainBuilder<Expressions::PowConstantExponent, Constant<exponent>> powConstantExponent;
 
 } // namespace vctr

--- a/include/vctr/PlatformVectorOps/AppleAccelerate.h
+++ b/include/vctr/PlatformVectorOps/AppleAccelerate.h
@@ -38,12 +38,13 @@ public:
     // vForce functions
     //==============================================================================
     // clang-format off
-    static void abs   (const float* src, float* dst, int len) { vvfabsf (dst, src, &len); }
-    static void ln    (const float* src, float* dst, int len) { vvlogf (dst, src, &len); }
-    static void log10 (const float* src, float* dst, int len) { vvlog10f (dst, src, &len); }
-    static void log2  (const float* src, float* dst, int len) { vvlog2f (dst, src, &len); }
-    static void exp   (const float* src, float* dst, int len) { vvexpf (dst, src, &len); }
-    static void exp2  (const float* src, float* dst, int len) { vvexp2f (dst, src, &len); }
+    static void abs   (const float* src,                    float* dst, int len) { vvfabsf (dst, src, &len); }
+    static void ln    (const float* src,                    float* dst, int len) { vvlogf (dst, src, &len); }
+    static void log10 (const float* src,                    float* dst, int len) { vvlog10f (dst, src, &len); }
+    static void log2  (const float* src,                    float* dst, int len) { vvlog2f (dst, src, &len); }
+    static void exp   (const float* src,                    float* dst, int len) { vvexpf (dst, src, &len); }
+    static void exp2  (const float* src,                    float* dst, int len) { vvexp2f (dst, src, &len); }
+    static void pow   (const float* base, const float* exp, float* dst, int len) { vvpowf (dst, exp, base, &len); }
     // clang-format on
 
     //==============================================================================
@@ -86,12 +87,14 @@ public:
     // vForce functions
     //==============================================================================
     // clang-format off
-    static void abs   (const double* src, double* dst, int len) { vvfabs (dst, src, &len); }
-    static void ln    (const double* src, double* dst, int len) { vvlog (dst, src, &len); }
-    static void log10 (const double* src, double* dst, int len) { vvlog10 (dst, src, &len); }
-    static void log2  (const double* src, double* dst, int len) { vvlog2 (dst, src, &len); }
-    static void exp   (const double* src, double* dst, int len) { vvexp (dst, src, &len); }
-    static void exp2  (const double* src, double* dst, int len) { vvexp2 (dst, src, &len); }
+    static void abs   (const double* src,                     double* dst, int len) { vvfabs (dst, src, &len); }
+    static void ln    (const double* src,                     double* dst, int len) { vvlog (dst, src, &len); }
+    static void log10 (const double* src,                     double* dst, int len) { vvlog10 (dst, src, &len); }
+    static void log2  (const double* src,                     double* dst, int len) { vvlog2 (dst, src, &len); }
+    static void exp   (const double* src,                     double* dst, int len) { vvexp (dst, src, &len); }
+    static void exp2  (const double* src,                     double* dst, int len) { vvexp2 (dst, src, &len); }
+    static void pow   (const double* base, const double* exp, double* dst, int len) { vvpow (dst, exp, base, &len); }
+
     // clang-format on
 
     //==============================================================================

--- a/include/vctr/PlatformVectorOps/IntelIPP.h
+++ b/include/vctr/PlatformVectorOps/IntelIPP.h
@@ -67,9 +67,11 @@ public:
     static void clampLow  (const float* src, float thresh, float* dst, int len) { assertIppNoErr (ippsThreshold_LT_32f (src, dst, len, thresh)); }
     static void clampHigh (const float* src, float thresh, float* dst, int len) { assertIppNoErr (ippsThreshold_GT_32f (src, dst, len, thresh)); }
 
-    static void ln    (const float* src, float* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLn_32f (src, dst, len)); }
-    static void log10 (const float* src, float* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLog10_32f_A24 (src, dst, len)); }
-    static void exp   (const float* src, float* dst, int len) { assertIppNoErr (ippsExp_32f (src, dst, len)); }
+    static void ln    (const float* src,                    float* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLn_32f (src, dst, len)); }
+    static void log10 (const float* src,                    float* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLog10_32f_A24 (src, dst, len)); }
+    static void exp   (const float* src,                    float* dst, int len) { assertIppNoErr (ippsExp_32f (src, dst, len)); }
+    static void pow   (const float* base, const float* exp, float* dst, int len) { assertIppNoErr (ippsPow_32f_A24 (base, exp, dst, len)); }
+    static void pow   (const float* base, float exp,        float* dst, int len) { assertIppNoErr (ippsPowx_32f_A24 (base, exp, dst, len)); }
 
     static float max    (const float* src, int len) { float r; assertIppNoErr (ippsMax_32f (src, len, &r)); return r; }
     static float maxAbs (const float* src, int len) { float r; assertIppNoErr (ippsMaxAbs_32f (src, len, &r)); return r; }
@@ -102,9 +104,11 @@ public:
     static void clampLow  (const double* src, float thresh,  double* dst, int len) { assertIppNoErr (ippsThreshold_LT_64f (src, dst, len, thresh)); }
     static void clampHigh (const double* src, float thresh,  double* dst, int len) { assertIppNoErr (ippsThreshold_GT_64f (src, dst, len, thresh)); }
 
-    static void ln    (const double* src, double* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLn_64f (src, dst, len)); }
-    static void log10 (const double* src, double* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLog10_64f_A53 (src, dst, len)); }
-    static void exp   (const double* src, double* dst, int len) { assertIppNoErr (ippsExp_64f (src, dst, len)); }
+    static void ln    (const double* src,                     double* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLn_64f (src, dst, len)); }
+    static void log10 (const double* src,                     double* dst, int len) { assertAllowedStatus<ippStsNoErr, ippStsSingularity> (ippsLog10_64f_A53 (src, dst, len)); }
+    static void exp   (const double* src,                     double* dst, int len) { assertIppNoErr (ippsExp_64f (src, dst, len)); }
+    static void pow   (const double* base, const double* exp, double* dst, int len) { assertIppNoErr (ippsPow_64f_A53 (base, exp, dst, len)); }
+    static void pow   (const double* base, double exp,        double* dst, int len) { assertIppNoErr (ippsPowx_64f_A53 (base, exp, dst, len)); }
 
     static double max    (const double* src, int len) { double r; assertIppNoErr (ippsMax_64f (src, len, &r)); return r; }
     static double maxAbs (const double* src, int len) { double r; assertIppNoErr (ippsMaxAbs_64f (src, len, &r)); return r; }
@@ -137,9 +141,11 @@ public:
 
     static void multiplyAccumulate (const std::complex<float>* srcA, const std::complex<float>* srcB, std::complex<float>* srcDst, int len) { assertIppNoErr (ippsAddProduct_32fc (fc (srcA), fc (srcB), fc (srcDst), len)); }
 
-    static void conj          (const std::complex<float>* src, std::complex<float>* dst, int len) { assertIppNoErr (ippsConj_32fc (fc (src), fc (dst), len)); }
-    static void angle         (const std::complex<float>* src, float* dst, int len)               { assertIppNoErr (ippsPhase_32fc (fc (src), dst, len)); }
-    static void powerSpectrum (const std::complex<float>* src, float* dst, int len)               { assertIppNoErr (ippsPowerSpectr_32fc (fc (src), dst, len)); }
+    static void angle         (const std::complex<float>* src,                                  float* dst,               int len) { assertIppNoErr (ippsPhase_32fc (fc (src), dst, len)); }
+    static void powerSpectrum (const std::complex<float>* src,                                  float* dst,               int len) { assertIppNoErr (ippsPowerSpectr_32fc (fc (src), dst, len)); }
+    static void conj          (const std::complex<float>* src,                                  std::complex<float>* dst, int len) { assertIppNoErr (ippsConj_32fc (fc (src), fc (dst), len)); }
+    static void pow           (const std::complex<float>* base, const std::complex<float>* exp, std::complex<float>* dst, int len) { assertIppNoErr (ippsPow_32fc_A24 (fc (base), fc (exp), fc (dst), len)); }
+    static void pow           (const std::complex<float>* base, std::complex<float> exp,        std::complex<float>* dst, int len) { assertIppNoErr (ippsPowx_32fc_A24 (fc (base), fc (exp), fc (dst), len)); }
 
     static std::complex<float> sum  (const std::complex<float>* src, int len) { std::complex<float> r; assertIppNoErr (ippsSum_32fc (fc (src), len, fc (&r), ippAlgHintNone)); return r; }
     static std::complex<float> mean (const std::complex<float>* src, int len) { std::complex<float> r; assertIppNoErr (ippsMean_32fc (fc (src), len, fc (&r), ippAlgHintNone)); return r;}
@@ -167,9 +173,11 @@ public:
 
     static void multiplyAccumulate (const std::complex<double>* srcA, const std::complex<double>* srcB, std::complex<double>* srcDst, int len) { assertIppNoErr (ippsAddProduct_64fc (fc (srcA), fc (srcB), fc (srcDst), len)); }
 
-    static void conj          (const std::complex<double>* src, std::complex<double>* dst, int len) { assertIppNoErr (ippsConj_64fc (fc (src), fc (dst), len)); }
-    static void angle         (const std::complex<double>* src, double* dst, int len)               { assertIppNoErr (ippsPhase_64fc (fc (src), dst, len)); }
-    static void powerSpectrum (const std::complex<double>* src, double* dst, int len)               { assertIppNoErr (ippsPowerSpectr_64fc (fc (src), dst, len)); }
+    static void angle         (const std::complex<double>* src,                                   double* dst,               int len) { assertIppNoErr (ippsPhase_64fc (fc (src), dst, len)); }
+    static void powerSpectrum (const std::complex<double>* src,                                   double* dst,               int len) { assertIppNoErr (ippsPowerSpectr_64fc (fc (src), dst, len)); }
+    static void conj          (const std::complex<double>* src,                                   std::complex<double>* dst, int len) { assertIppNoErr (ippsConj_64fc (fc (src), fc (dst), len)); }
+    static void pow           (const std::complex<double>* base, const std::complex<double>* exp, std::complex<double>* dst, int len) { assertIppNoErr (ippsPow_64fc_A53 (fc (base), fc (exp), fc (dst), len)); }
+    static void pow           (const std::complex<double>* base, std::complex<double> exp,        std::complex<double>* dst, int len) { assertIppNoErr (ippsPowx_64fc_A53 (fc (base), fc (exp), fc (dst), len)); }
 
     static std::complex<double> sum  (const std::complex<double>* src, int len) { std::complex<double> r; assertIppNoErr (ippsSum_64fc (fc (src), len, fc (&r))); return r; }
     static std::complex<double> mean (const std::complex<double>* src, int len) { std::complex<double> r; assertIppNoErr (ippsMean_64fc (fc (src), len, fc (&r))); return r;}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources (vctr_test PRIVATE
         TestCases/Expressions/Max.cpp
         TestCases/Expressions/Mean.cpp
         TestCases/Expressions/Min.cpp
+        TestCases/Expressions/Pow.cpp
         TestCases/Expressions/PowerSpectrum.cpp
         TestCases/Expressions/RealImag.cpp
         TestCases/Expressions/Subtract.cpp

--- a/test/TestCases/Expressions/Pow.cpp
+++ b/test/TestCases/Expressions/Pow.cpp
@@ -1,0 +1,85 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+// The Linux builds failed with templated functions. Could be cleaned up at some point.
+// clang-format off
+float                power (float base,                float exp)                { return std::pow (base, exp); }
+double               power (double base,               double exp)               { return std::pow (base, exp); }
+double               power (int32_t base,              int32_t exp)              { return std::pow (base, exp); }
+double               power (int64_t base,              int64_t exp)              { return std::pow (base, exp); }
+std::complex<float>  power (std::complex<float> base,  std::complex<float> exp)  { return std::pow (base, exp); }
+std::complex<double> power (std::complex<double> base, std::complex<double> exp) { return std::pow (base, exp); }
+
+template <int32_t base> float                powerConstantBase (float exp)                { return std::pow (float (base), exp); }
+template <int32_t base> double               powerConstantBase (double exp)               { return std::pow (double (base), exp); }
+template <int32_t base> double               powerConstantBase (int32_t exp)              { return std::pow (base, exp); }
+template <int64_t base> double               powerConstantBase (int64_t exp)              { return std::pow (base, exp); }
+template <int32_t base> std::complex<float>  powerConstantBase (std::complex<float> exp)  { return std::pow (std::complex<float> (base), exp); }
+template <int32_t base> std::complex<double> powerConstantBase (std::complex<double> exp) { return std::pow (std::complex<double> (base), exp); }
+
+template <int32_t exp> float                powerConstantExp (float base)                { return std::pow (base, exp); }
+template <int32_t exp> double               powerConstantExp (double base)               { return std::pow (base, exp); }
+template <int32_t exp> double               powerConstantExp (int32_t base)              { return std::pow (base, exp); }
+template <int64_t exp> double               powerConstantExp (int64_t base)              { return std::pow (base, exp); }
+template <int32_t exp> std::complex<float>  powerConstantExp (std::complex<float> base)  { return std::pow (base, std::complex<float> (exp)); }
+template <int32_t exp> std::complex<double> powerConstantExp (std::complex<double> base) { return std::pow (base, std::complex<double> (exp)); }
+// clang-format on
+
+TEMPLATE_PRODUCT_TEST_CASE ("Pow", "[pow]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, std::complex<float>, std::complex<double>))
+{
+    VCTR_TEST_DEFINES_IN_RANGE (0, 15, 10)
+
+    // For non-integral values we want to test with negative exponents
+    constexpr int singleExponent = std::is_integral_v<ElementType> ? 5 : -4;
+
+    SECTION ("Vector raised to the power of Vector")
+    {
+        const vctr::Vector p = filter << vctr::pow (srcA, srcB);
+        REQUIRE_THAT (p, vctr::EqualsTransformedBy<power> (srcA, srcB).withEpsilon (0.00001));
+    }
+
+    SECTION ("Vector raised to the power of a single value")
+    {
+        const vctr::Vector p = filter << vctr::pow (srcA, ElementType (singleExponent));
+        REQUIRE_THAT (p, vctr::EqualsTransformedBy<powerConstantExp<singleExponent>> (srcA).withEpsilon (0.00001));
+    }
+
+    SECTION ("Single value raised to the power of Vector")
+    {
+        const vctr::Vector p = filter << vctr::pow (3.0f, srcA);
+        REQUIRE_THAT (p, vctr::EqualsTransformedBy<powerConstantBase<3>> (srcA));
+    }
+
+    SECTION ("Vector raised to the power of a compile time constant value")
+    {
+        const vctr::Vector p = filter << vctr::powConstantExponent<singleExponent> << srcA;
+        REQUIRE_THAT (p, vctr::EqualsTransformedBy<powerConstantExp<singleExponent>> (srcA).withEpsilon (0.00001));
+    }
+
+    SECTION ("Compile time constant value raised to the power of Vector")
+    {
+        const vctr::Vector p = filter << vctr::powConstantBase<4> << srcA;
+        REQUIRE_THAT (p, vctr::EqualsTransformedBy<powerConstantBase<4>> (srcA));
+    }
+}

--- a/test/TestCases/Expressions/Sum.cpp
+++ b/test/TestCases/Expressions/Sum.cpp
@@ -33,7 +33,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sum", "[sum]", (PlatformVectorOps, VCTR_NATIVE_SIMD
     const auto ref = std::reduce (srcA.begin(), srcA.end());
     const auto refU = std::reduce (srcUnaligned.begin(), srcUnaligned.end());
 
-    const auto eps = vctr::RealType<ElementType> (0.00001);
+    const auto eps = vctr::RealType<ElementType> (0.00002);
 
     if constexpr (vctr::is::complexFloatNumber<ElementType>)
     {

--- a/test/include/vctr_test_utils/Matchers/EqualsTransformedBy.h
+++ b/test/include/vctr_test_utils/Matchers/EqualsTransformedBy.h
@@ -82,8 +82,12 @@ struct UnaryEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBase
 
     std::string describe() const override
     {
+        Vector<RetValueType> refResult (reference.size());
+
+        std::transform (reference.begin(), reference.end(), refResult.begin(), transformingFn);
+
         std::ostringstream os;
-        os << "Equals: " << vctr::functionName<RetValueType, SrcValueType, transformingFn>() << " (" << reference << ")";
+        os << "Equals: " << vctr::functionName<RetValueType, SrcValueType, transformingFn>() << " (" << reference << ") = " << refResult;
         return os.str();
     }
 
@@ -94,7 +98,7 @@ private:
     double epsilon = 0.0;
 };
 
-template <class ValueType, is::anyVctr ReferenceVecA, is::anyVctr ReferenceVecB, ValueType (*transformingFn) (ValueType, ValueType)>
+template <class RetValueType, class SrcValueType, is::anyVctr ReferenceVecA, is::anyVctr ReferenceVecB, RetValueType (*transformingFn) (SrcValueType, SrcValueType)>
 struct BinaryEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBase
 {
     BinaryEqualsTransformedMatcher (const ReferenceVecA& vecA, const ReferenceVecB& vecB)
@@ -113,7 +117,7 @@ struct BinaryEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBase
         for (size_t i = 0; i < vec.size(); ++i)
         {
             auto v = transformingFn (referenceA[i], referenceB[i]);
-            if (Approx<ValueType> (v).margin (margin).epsilon (epsilon) != vec[i])
+            if (Approx<RetValueType> (v).margin (margin).epsilon (epsilon) != vec[i])
                 return false;
         }
 
@@ -121,15 +125,19 @@ struct BinaryEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBase
     }
 
     // clang-format off
-        auto withMargin (double m) &&                                                                    { margin = m; return std::move (*this); }
-        auto withEpsilon (double e = std::numeric_limits<vctr::RealType<ValueType>>::epsilon() * 100) && { epsilon = e; return std::move (*this); }
+        auto withMargin (double m) &&                                                                       { margin = m; return std::move (*this); }
+        auto withEpsilon (double e = std::numeric_limits<vctr::RealType<RetValueType>>::epsilon() * 100) && { epsilon = e; return std::move (*this); }
     // clang-format on
 
     std::string describe() const override
     {
+        Vector<RetValueType> refResult (referenceA.size());
+
+        std::transform (referenceA.begin(), referenceA.end(), referenceB.begin(), refResult.begin(), transformingFn);
+
         std::ostringstream os;
-        os << "Equals: " << vctr::functionName<ValueType, ValueType, ValueType, transformingFn>() << " (" << referenceA
-           << ", " << referenceB << ")";
+        os << "Equals: " << vctr::functionName<RetValueType, SrcValueType, SrcValueType, transformingFn>() << " (" << referenceA
+           << ", " << referenceB << ") = " << refResult;
         return os.str();
     }
 
@@ -147,13 +155,15 @@ struct BinaryScalarEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBas
     BinaryScalarEqualsTransformedMatcher (const ReferenceVec& vec, ValueType scalar)
         : referenceVec (vec),
           referenceScalar (scalar),
-          swapReferences (false)
+          scalarBeforeVec (false),
+          fnWithBoundScalar ([=] (ValueType v) { return transformingFn (v, scalar); })
     {}
 
     BinaryScalarEqualsTransformedMatcher (ValueType scalar, const ReferenceVec& vec)
         : referenceVec (vec),
           referenceScalar (scalar),
-          swapReferences (true)
+          scalarBeforeVec (true),
+          fnWithBoundScalar ([=] (ValueType v) { return transformingFn (scalar, v); })
     {}
 
     template <is::anyVctr Vec>
@@ -164,8 +174,7 @@ struct BinaryScalarEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBas
 
         for (size_t i = 0; i < vec.size(); ++i)
         {
-            auto v = swapReferences ? transformingFn (referenceScalar, referenceVec[i])
-                                    : transformingFn (referenceVec[i], referenceScalar);
+            auto v = fnWithBoundScalar (referenceVec[i]);
 
             if (Approx<ValueType> (v).margin (margin).epsilon (epsilon) != vec[i])
                 return false;
@@ -187,108 +196,127 @@ struct BinaryScalarEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBas
 
     std::string describe() const override
     {
+        Vector<ValueType> refResult (referenceVec.size());
+
+        std::transform (referenceVec.begin(), referenceVec.end(), refResult.begin(), fnWithBoundScalar);
+
         std::ostringstream os;
-        os << "Equals: " << vctr::functionName<ValueType, ValueType, ValueType, transformingFn>() << " (" << referenceVec
-           << ", " << referenceScalar << ")";
+        os << "Equals: " << vctr::functionName<ValueType, ValueType, ValueType, transformingFn>() << " (";
+
+        if (scalarBeforeVec)
+            os << referenceScalar << ", " << referenceVec;
+        else
+            os << referenceVec << ", " << referenceScalar;
+
+        os << ") = " << refResult;
+
         return os.str();
     }
 
 private:
     const ReferenceVec& referenceVec;
     const ValueType referenceScalar;
-    const bool swapReferences;
+    const bool scalarBeforeVec;
+    const std::function<ValueType (ValueType)> fnWithBoundScalar;
 
     double margin = 0.0;
     double epsilon = 0.0;
 };
 } // namespace detail
 
-#define VCTR_DEFINE_EQUAL_TRANSFORMED_BY_FOR_TYPE(T)                                                                 \
-                                                                                                                     \
-    template <T (*fn) (T), is::anyVctr ReferenceVec>                                                                 \
-    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                 \
-    auto EqualsTransformedBy (const ReferenceVec& vec)                                                               \
-    {                                                                                                                \
-        return detail::UnaryEqualsTransformedMatcher<T, T, ReferenceVec, fn> (vec);                                  \
-    }                                                                                                                \
-                                                                                                                     \
-    template <T (*fn) (const std::complex<T>&), is::anyVctr ReferenceVec>                                            \
-    requires std::floating_point<T> &&                                                                               \
-             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                   \
-    auto EqualsTransformedBy (const ReferenceVec& vec)                                                               \
-    {                                                                                                                \
-        return detail::UnaryEqualsTransformedMatcher<T, const std::complex<T>&, ReferenceVec, fn> (vec);             \
-    }                                                                                                                \
-                                                                                                                     \
-    template <T (*fn) (std::complex<T>), is::anyVctr ReferenceVec>                                                   \
-    requires std::floating_point<T> &&                                                                               \
-             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                   \
-    auto EqualsTransformedBy (const ReferenceVec& vec)                                                               \
-    {                                                                                                                \
-        return detail::UnaryEqualsTransformedMatcher<T, std::complex<T>, ReferenceVec, fn> (vec);                    \
-    }                                                                                                                \
-                                                                                                                     \
-    template <std::complex<T> (*fn) (std::complex<T>), is::anyVctr ReferenceVec>                                     \
-    requires std::floating_point<T> &&                                                                               \
-             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                   \
-    auto EqualsTransformedBy (const ReferenceVec& vec)                                                               \
-    {                                                                                                                \
-        return detail::UnaryEqualsTransformedMatcher<std::complex<T>, std::complex<T>, ReferenceVec, fn> (vec);      \
-    }                                                                                                                \
-                                                                                                                     \
-    template <T (*fn) (T, T), is::anyVctr ReferenceVec>                                                              \
-    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                 \
-    auto EqualsTransformedBy (const ReferenceVec& vecA, const ReferenceVec& vecB)                                    \
-    {                                                                                                                \
-        return detail::BinaryEqualsTransformedMatcher<T, ReferenceVec, ReferenceVec, fn> (vecA, vecB);               \
-    }                                                                                                                \
-                                                                                                                     \
-    template <T (*fn) (T, T), is::anyVctr ReferenceVec>                                                              \
-    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                 \
-    auto EqualsTransformedBy (const ReferenceVec& vec, T scalar)                                                     \
-    {                                                                                                                \
-        return detail::BinaryScalarEqualsTransformedMatcher<T, ReferenceVec, fn> (vec, scalar);                      \
-    }                                                                                                                \
-                                                                                                                     \
-    template <T (*fn) (T, T), is::anyVctr ReferenceVec>                                                              \
-    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                 \
-    auto EqualsTransformedBy (T scalar, const ReferenceVec& vec)                                                     \
-    {                                                                                                                \
-        return detail::BinaryScalarEqualsTransformedMatcher<T, ReferenceVec, fn> (scalar, vec);                      \
-    }                                                                                                                \
-                                                                                                                     \
-    template <std::complex<T> (*fn) (std::complex<T>, std::complex<T>), is::anyVctr ReferenceVec>                    \
-    requires std::floating_point<T> &&                                                                               \
-             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                   \
-    auto EqualsTransformedBy (const ReferenceVec& vecA, const ReferenceVec& vecB)                                    \
-    {                                                                                                                \
-        return detail::BinaryEqualsTransformedMatcher<std::complex<T>, ReferenceVec, ReferenceVec, fn> (vecA, vecB); \
-    }                                                                                                                \
-                                                                                                                     \
-    template <std::complex<T> (*fn) (std::complex<T>, std::complex<T>), is::anyVctr ReferenceVec>                    \
-    requires std::floating_point<T> &&                                                                               \
-             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                   \
-    auto EqualsTransformedBy (const ReferenceVec& vec, std::complex<T> scalar)                                       \
-    {                                                                                                                \
-        return detail::BinaryScalarEqualsTransformedMatcher<std::complex<T>, ReferenceVec, fn> (vec, scalar);        \
-    }                                                                                                                \
-                                                                                                                     \
-    template <std::complex<T> (*fn) (std::complex<T>, std::complex<T>), is::anyVctr ReferenceVec>                    \
-    requires std::floating_point<T> &&                                                                               \
-             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                   \
-    auto EqualsTransformedBy (std::complex<T> scalar, const ReferenceVec& vec)                                       \
-    {                                                                                                                \
-        return detail::BinaryScalarEqualsTransformedMatcher<std::complex<T>, ReferenceVec, fn> (scalar, vec);        \
+#define VCTR_DEFINE_EQUAL_TRANSFORMED_BY_FOR_TYPE(T)                                                                                  \
+                                                                                                                                      \
+    template <T (*fn) (T), is::anyVctr ReferenceVec>                                                                                  \
+    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                                  \
+    auto EqualsTransformedBy (const ReferenceVec& vec)                                                                                \
+    {                                                                                                                                 \
+        return detail::UnaryEqualsTransformedMatcher<T, T, ReferenceVec, fn> (vec);                                                   \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <T (*fn) (const std::complex<T>&), is::anyVctr ReferenceVec>                                                             \
+    requires std::floating_point<T> &&                                                                                                \
+             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                                    \
+    auto EqualsTransformedBy (const ReferenceVec& vec)                                                                                \
+    {                                                                                                                                 \
+        return detail::UnaryEqualsTransformedMatcher<T, const std::complex<T>&, ReferenceVec, fn> (vec);                              \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <T (*fn) (std::complex<T>), is::anyVctr ReferenceVec>                                                                    \
+    requires std::floating_point<T> &&                                                                                                \
+             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                                    \
+    auto EqualsTransformedBy (const ReferenceVec& vec)                                                                                \
+    {                                                                                                                                 \
+        return detail::UnaryEqualsTransformedMatcher<T, std::complex<T>, ReferenceVec, fn> (vec);                                     \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <std::complex<T> (*fn) (std::complex<T>), is::anyVctr ReferenceVec>                                                      \
+    requires std::floating_point<T> &&                                                                                                \
+             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                                    \
+    auto EqualsTransformedBy (const ReferenceVec& vec)                                                                                \
+    {                                                                                                                                 \
+        return detail::UnaryEqualsTransformedMatcher<std::complex<T>, std::complex<T>, ReferenceVec, fn> (vec);                       \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <T (*fn) (T, T), is::anyVctr ReferenceVec>                                                                               \
+    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                                  \
+    auto EqualsTransformedBy (const ReferenceVec& vecA, const ReferenceVec& vecB)                                                     \
+    {                                                                                                                                 \
+        return detail::BinaryEqualsTransformedMatcher<T, T, ReferenceVec, ReferenceVec, fn> (vecA, vecB);                             \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <T (*fn) (T, T), is::anyVctr ReferenceVec>                                                                               \
+    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                                  \
+    auto EqualsTransformedBy (const ReferenceVec& vec, T scalar)                                                                      \
+    {                                                                                                                                 \
+        return detail::BinaryScalarEqualsTransformedMatcher<T, ReferenceVec, fn> (vec, scalar);                                       \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <T (*fn) (T, T), is::anyVctr ReferenceVec>                                                                               \
+    requires std::same_as<T, std::remove_const_t<typename ReferenceVec::value_type>>                                                  \
+    auto EqualsTransformedBy (T scalar, const ReferenceVec& vec)                                                                      \
+    {                                                                                                                                 \
+        return detail::BinaryScalarEqualsTransformedMatcher<T, ReferenceVec, fn> (scalar, vec);                                       \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <std::complex<T> (*fn) (std::complex<T>, std::complex<T>), is::anyVctr ReferenceVec>                                     \
+    requires std::floating_point<T> &&                                                                                                \
+             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                                    \
+    auto EqualsTransformedBy (const ReferenceVec& vecA, const ReferenceVec& vecB)                                                     \
+    {                                                                                                                                 \
+        return detail::BinaryEqualsTransformedMatcher<std::complex<T>, std::complex<T>, ReferenceVec, ReferenceVec, fn> (vecA, vecB); \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <std::complex<T> (*fn) (std::complex<T>, std::complex<T>), is::anyVctr ReferenceVec>                                     \
+    requires std::floating_point<T> &&                                                                                                \
+             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                                    \
+    auto EqualsTransformedBy (const ReferenceVec& vec, std::complex<T> scalar)                                                        \
+    {                                                                                                                                 \
+        return detail::BinaryScalarEqualsTransformedMatcher<std::complex<T>, ReferenceVec, fn> (vec, scalar);                         \
+    }                                                                                                                                 \
+                                                                                                                                      \
+    template <std::complex<T> (*fn) (std::complex<T>, std::complex<T>), is::anyVctr ReferenceVec>                                     \
+    requires std::floating_point<T> &&                                                                                                \
+             std::same_as<std::complex<T>, std::remove_const_t<typename ReferenceVec::value_type>>                                    \
+    auto EqualsTransformedBy (std::complex<T> scalar, const ReferenceVec& vec)                                                        \
+    {                                                                                                                                 \
+        return detail::BinaryScalarEqualsTransformedMatcher<std::complex<T>, ReferenceVec, fn> (scalar, vec);                         \
     }
 
-#define VCTR_DEFINE_EQUAL_TRANSFORMED_BY_FOR_TYPE_CONVERTING(SrcT, DstT)                  \
-                                                                                          \
-    template <DstT (*fn) (SrcT), is::anyVctr ReferenceVec>                                \
-    requires std::same_as<SrcT, std::remove_const_t<typename ReferenceVec::value_type>>   \
-    auto EqualsTransformedBy (const ReferenceVec& vec)                                    \
-    {                                                                                     \
-        return detail::UnaryEqualsTransformedMatcher<DstT, SrcT, ReferenceVec, fn> (vec); \
-    }
+#define VCTR_DEFINE_EQUAL_TRANSFORMED_BY_FOR_TYPE_CONVERTING(SrcT, DstT)                                    \
+                                                                                                            \
+    template <DstT (*fn) (SrcT), is::anyVctr ReferenceVec>                                                  \
+    requires std::same_as<SrcT, std::remove_const_t<typename ReferenceVec::value_type>>                     \
+    auto EqualsTransformedBy (const ReferenceVec& vec)                                                      \
+    {                                                                                                       \
+        return detail::UnaryEqualsTransformedMatcher<DstT, SrcT, ReferenceVec, fn> (vec);                   \
+    }                                                                                                       \
+                                                                                                            \
+template <DstT (*fn) (SrcT, SrcT), is::anyVctr ReferenceVec>                                                \
+requires std::same_as<SrcT, std::remove_const_t<typename ReferenceVec::value_type>>                         \
+auto EqualsTransformedBy (const ReferenceVec& vecA, const ReferenceVec& vecB)                               \
+{                                                                                                           \
+    return detail::BinaryEqualsTransformedMatcher<DstT, SrcT, ReferenceVec, ReferenceVec, fn> (vecA, vecB); \
+}
 
 VCTR_DEFINE_EQUAL_TRANSFORMED_BY_FOR_TYPE (float)
 VCTR_DEFINE_EQUAL_TRANSFORMED_BY_FOR_TYPE (double)


### PR DESCRIPTION
I added some macros to avoid repeating boilerplate code for binary expressions. I'd like to do some further refactoring for the existing `VCTR_COMMON_UNARY_EXPRESSION_MEMBERS` macro and rework the handling of SIMD registers in `VCTR_COMMON_BINARY_SINGLE_VEC_EXPRESSION_MEMBERS`, but decided to introduce this changes step by step along with the upcoming PRs to not bloat the diff too much ;) 