### PR TITLE
Vctr 56 implement map normalize

### DIFF
--- a/include/vctr/Containers/VctrBase.tpp
+++ b/include/vctr/Containers/VctrBase.tpp
@@ -52,14 +52,14 @@ template <is::anyVctrOrExpression V>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator*= (const V& v)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::MultiplyVectors<extent, decltype (self), const V&> (self, v));
+    assignExpressionTemplate (expressions::MultiplyVectors<extent, decltype (self), const V&> (self, v));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator*= (value_type c)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::MultiplyVecBySingle<extent, decltype (self)> (c, self));
+    assignExpressionTemplate (expressions::MultiplyVecBySingle<extent, decltype (self)> (c, self));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
@@ -67,14 +67,14 @@ template <is::anyVctrOrExpression V>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator/= (const V& v)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::DivideVectors<extent, decltype (self), const V&> (self, v));
+    assignExpressionTemplate (expressions::DivideVectors<extent, decltype (self), const V&> (self, v));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator/= (value_type c)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::DivideVecBySingle<extent, decltype (self)> (c, self));
+    assignExpressionTemplate (expressions::DivideVecBySingle<extent, decltype (self)> (c, self));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
@@ -90,14 +90,14 @@ constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::oper
     }
 
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::AddVectors<extent, decltype (self), const V&> (self, v));
+    assignExpressionTemplate (expressions::AddVectors<extent, decltype (self), const V&> (self, v));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator+= (value_type c)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::AddSingleToVec<extent, decltype (self)> (c, self));
+    assignExpressionTemplate (expressions::AddSingleToVec<extent, decltype (self)> (c, self));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
@@ -105,14 +105,14 @@ template <is::anyVctrOrExpression V>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator-= (const V& v)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::SubtractVectors<extent, decltype (self), const V&> (self, v));
+    assignExpressionTemplate (expressions::SubtractVectors<extent, decltype (self), const V&> (self, v));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>
 constexpr void VctrBase<ElementType, StorageType, extent, StorageInfoType>::operator-= (value_type c)
 {
     const auto& self = *this;
-    assignExpressionTemplate (Expressions::SubtractSingleFromVec<extent, decltype (self)> (c, self));
+    assignExpressionTemplate (expressions::SubtractSingleFromVec<extent, decltype (self)> (c, self));
 }
 
 template <class ElementType, class StorageType, size_t extent, class StorageInfoType>

--- a/include/vctr/Expressions/BasicMath/Abs.h
+++ b/include/vctr/Expressions/BasicMath/Abs.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -120,7 +120,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -130,6 +130,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Abs> abs;
+constexpr inline ExpressionChainBuilder<expressions::Abs> abs;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Add.h
+++ b/include/vctr/Expressions/BasicMath/Add.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 //==============================================================================
@@ -126,7 +126,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -141,7 +141,7 @@ constexpr auto operator+ (SrcAType&& a, SrcBType&& b)
     assertCommonSize (a, b);
     constexpr auto extent = getCommonExtent<SrcAType, SrcBType>();
 
-    return Expressions::AddVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
+    return expressions::AddVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
 }
 
 /** Returns an expression that adds a single value to a vector or expression source.
@@ -151,7 +151,7 @@ constexpr auto operator+ (SrcAType&& a, SrcBType&& b)
 template <is::anyVctrOrExpression Src>
 constexpr auto operator+ (typename std::remove_cvref_t<Src>::value_type single, Src&& vec)
 {
-    return Expressions::AddSingleToVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::AddSingleToVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 /** Returns an expression that adds a vector or expression source to a single value.
@@ -161,7 +161,7 @@ constexpr auto operator+ (typename std::remove_cvref_t<Src>::value_type single, 
 template <is::anyVctrOrExpression Src>
 constexpr auto operator+ (Src&& vec, typename std::remove_cvref_t<Src>::value_type single)
 {
-    return Expressions::AddSingleToVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::AddSingleToVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Clamp.h
+++ b/include/vctr/Expressions/BasicMath/Clamp.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType, is::constantWithType<bool> ClampLow, is::constantWithType<bool> ClampHigh>
@@ -183,7 +183,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -198,7 +198,7 @@ namespace vctr
 template <class T>
 constexpr auto clampLow (T lowerBound)
 {
-    return makeExpressionChainBuilderWithRuntimeArgs<Expressions::ClampLow> (lowerBound, std::numeric_limits<T>::max());
+    return makeExpressionChainBuilderWithRuntimeArgs<expressions::ClampLow> (lowerBound, std::numeric_limits<T>::max());
 }
 
 /** Ensures that the elements are not greater than upperBound.
@@ -211,7 +211,7 @@ constexpr auto clampLow (T lowerBound)
 template <class T>
 constexpr auto clampHigh (T upperBound)
 {
-    return makeExpressionChainBuilderWithRuntimeArgs<Expressions::ClampHigh> (std::numeric_limits<T>::max(), upperBound);
+    return makeExpressionChainBuilderWithRuntimeArgs<expressions::ClampHigh> (std::numeric_limits<T>::max(), upperBound);
 }
 
 /** Ensures that the elements are not lower than lowerBound and not higher than upperBound.
@@ -224,7 +224,7 @@ constexpr auto clampHigh (T upperBound)
 template <class T>
 constexpr auto clamp (T lowerBound, T upperBound)
 {
-    return makeExpressionChainBuilderWithRuntimeArgs<Expressions::ClampLowHigh> (lowerBound, upperBound);
+    return makeExpressionChainBuilderWithRuntimeArgs<expressions::ClampLowHigh> (lowerBound, upperBound);
 }
 
 
@@ -238,7 +238,7 @@ constexpr auto clamp (T lowerBound, T upperBound)
     @ingroup Expressions
  */
 template <auto lowerBound>
-constexpr inline ExpressionChainBuilder<Expressions::ClampByConstant, Constant<lowerBound>, DisabledConstant> clampLowByConstant;
+constexpr inline ExpressionChainBuilder<expressions::ClampByConstant, Constant<lowerBound>, DisabledConstant> clampLowByConstant;
 
 /** Ensures that the elements are not higher than upperBound.
 
@@ -249,7 +249,7 @@ constexpr inline ExpressionChainBuilder<Expressions::ClampByConstant, Constant<l
     @ingroup Expressions
  */
 template <auto upperBound>
-constexpr inline ExpressionChainBuilder<Expressions::ClampByConstant, DisabledConstant, Constant<upperBound>> clampHighByConstant;
+constexpr inline ExpressionChainBuilder<expressions::ClampByConstant, DisabledConstant, Constant<upperBound>> clampHighByConstant;
 
 /** Ensures that the elements are not lower than lowerBound and not higher than upperBound.
 
@@ -260,6 +260,6 @@ constexpr inline ExpressionChainBuilder<Expressions::ClampByConstant, DisabledCo
     @ingroup Expressions
  */
 template <auto lowerBound, auto upperBound>
-constexpr inline ExpressionChainBuilder<Expressions::ClampByConstant, Constant<lowerBound>, Constant<upperBound>> clampByConstant;
+constexpr inline ExpressionChainBuilder<expressions::ClampByConstant, Constant<lowerBound>, Constant<upperBound>> clampByConstant;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Cube.h
+++ b/include/vctr/Expressions/BasicMath/Cube.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -68,7 +68,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -77,6 +77,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Cube> cube;
+constexpr inline ExpressionChainBuilder<expressions::Cube> cube;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Divide.h
+++ b/include/vctr/Expressions/BasicMath/Divide.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 //==============================================================================
@@ -154,7 +154,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -171,7 +171,7 @@ constexpr auto operator/ (SrcAType&& a, SrcBType&& b)
     assertCommonSize (a, b);
     constexpr auto extent = getCommonExtent<SrcAType, SrcBType>();
 
-    return Expressions::DivideVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
+    return expressions::DivideVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
 }
 
 /** Returns an expression that divides a single value by a vector or expression source.
@@ -182,7 +182,7 @@ template <class Src>
 requires is::anyVctrOrExpression<Src>
 constexpr auto operator/ (typename std::remove_cvref_t<Src>::value_type single, Src&& vec)
 {
-    return Expressions::DivideSingleByVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::DivideSingleByVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 /** Returns an expression that divides a vector or expression source by a single value.
@@ -193,7 +193,7 @@ template <class Src>
 requires is::anyVctrOrExpression<Src>
 constexpr auto operator/ (Src&& vec, typename std::remove_cvref_t<Src>::value_type single)
 {
-    return Expressions::DivideVecBySingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::DivideVecBySingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Max.h
+++ b/include/vctr/Expressions/BasicMath/Max.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -182,7 +182,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -191,12 +191,12 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Max> max;
+constexpr inline ExpressionChainBuilder<expressions::Max> max;
 
 /** Computes the maximum value of the absolute value of the source values.
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::MaxAbs> maxAbs;
+constexpr inline ExpressionChainBuilder<expressions::MaxAbs> maxAbs;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Mean.h
+++ b/include/vctr/Expressions/BasicMath/Mean.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -219,7 +219,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -228,18 +228,18 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Mean> mean;
+constexpr inline ExpressionChainBuilder<expressions::Mean> mean;
 
 /** Computes the mean value of the squared source values.
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::MeanSquare> meanSquare;
+constexpr inline ExpressionChainBuilder<expressions::MeanSquare> meanSquare;
 
 /** Computes the square root of the mean value of the squared source values.
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::RootMeanSquare> rms;
+constexpr inline ExpressionChainBuilder<expressions::RootMeanSquare> rms;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Min.h
+++ b/include/vctr/Expressions/BasicMath/Min.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -182,7 +182,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -191,11 +191,11 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Min> min;
+constexpr inline ExpressionChainBuilder<expressions::Min> min;
 
 /** Computes the minimum value of the absolute value of the source values.
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::MinAbs> minAbs;
+constexpr inline ExpressionChainBuilder<expressions::MinAbs> minAbs;
 }

--- a/include/vctr/Expressions/BasicMath/Multiply.h
+++ b/include/vctr/Expressions/BasicMath/Multiply.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 //==============================================================================
@@ -214,7 +214,7 @@ private:
     const typename Expression::NeonSrc asNeon;
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr::detail
 {
@@ -222,10 +222,10 @@ template <class T>
 struct IsMultiplicationExpression : std::false_type {};
 
 template <size_t e, class A, class B>
-struct IsMultiplicationExpression<Expressions::MultiplyVectors<e, A, B>> : std::true_type {};
+struct IsMultiplicationExpression<expressions::MultiplyVectors<e, A, B>> : std::true_type {};
 
 template <size_t e, class A>
-struct IsMultiplicationExpression<Expressions::MultiplyVecBySingle<e, A>> : std::true_type {};
+struct IsMultiplicationExpression<expressions::MultiplyVecBySingle<e, A>> : std::true_type {};
 } // namespace vctr::detail
 
 namespace vctr
@@ -243,7 +243,7 @@ constexpr auto operator* (SrcAType&& a, SrcBType&& b)
     assertCommonSize (a, b);
     constexpr auto extent = getCommonExtent<SrcAType, SrcBType>();
 
-    return Expressions::MultiplyVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
+    return expressions::MultiplyVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
 }
 
 /** Returns an expression that multiplies a single value with a vector or expression source.
@@ -254,7 +254,7 @@ template <class Src>
 requires is::anyVctrOrExpression<Src>
 constexpr auto operator* (typename std::remove_cvref_t<Src>::value_type single, Src&& vec)
 {
-    return Expressions::MultiplyVecBySingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::MultiplyVecBySingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 /** Returns an expression that multiplies a vector or expression source with a single value.
@@ -265,7 +265,7 @@ template <class Src>
 requires is::anyVctrOrExpression<Src>
 constexpr auto operator* (Src&& vec, typename std::remove_cvref_t<Src>::value_type single)
 {
-    return Expressions::MultiplyVecBySingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::MultiplyVecBySingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 
@@ -274,5 +274,5 @@ constexpr auto operator* (Src&& vec, typename std::remove_cvref_t<Src>::value_ty
     @ingroup Expressions
  */
 template <auto constantValue>
-constexpr inline ExpressionChainBuilder<Expressions::MultiplyVecByConstant, Constant<constantValue>> multiplyByConstant;
+constexpr inline ExpressionChainBuilder<expressions::MultiplyVecByConstant, Constant<constantValue>> multiplyByConstant;
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/NormalizeSum.h
+++ b/include/vctr/Expressions/BasicMath/NormalizeSum.h
@@ -1,0 +1,88 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr::expressions
+{
+
+template <size_t extent, class SrcType>
+requires is::floatNumber<ValueType<SrcType>>
+class NormalizeSum : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcType>;
+
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (NormalizeSum, src)
+
+    void applyRuntimeArgs()
+    {
+        srcSum = sum << src;
+    }
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+        VCTR_ASSERT (srcSum != value_type (0));
+        return src[i] / srcSum;
+    }
+
+    //==============================================================================
+    // Platform Vector Operation Implementation
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable>
+    {
+        VCTR_ASSERT (srcSum != value_type (0));
+        Expression::Accelerate::div (src.evalNextVectorOpInExpressionChain (dst), srcSum, dst, size());
+        return dst;
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealFloatVectorOp<SrcType, value_type, detail::preferIfIppAndAccelerateAreAvailable>
+    {
+        VCTR_ASSERT (srcSum != value_type (0));
+        Expression::IPP::div (src.evalNextVectorOpInExpressionChain (dst), srcSum, dst, size());
+        return dst;
+    }
+
+private:
+    //==============================================================================
+    value_type srcSum = value_type (0);
+};
+
+}
+
+namespace vctr
+{
+
+/** Computes the sum of the source elements and divides all source elements by that sum.
+
+    Note: If the source is an expression itself, that source expression will possibly be evaluated twice
+    since we need to evaluate it once to compute the sum and then again to compute the normalized expression
+    result. For performance critical applications, you should consider buffering a source expression to an
+    intermediate container.
+
+    @attention The required sum is computed once when the source is assigned to the expression. In case
+    the source values are changed after that time point, evaluating the expression will use an outdated
+    sum. Therefore, we might consider deprecating and eventually removing this expression in a future release.
+
+    @ingroup Expressions
+ */
+constexpr inline ExpressionChainBuilder<expressions::NormalizeSum> normalizeSum;
+}

--- a/include/vctr/Expressions/BasicMath/Sqrt.h
+++ b/include/vctr/Expressions/BasicMath/Sqrt.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -71,7 +71,7 @@ private:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -80,6 +80,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Sqrt> sqrt;
+constexpr inline ExpressionChainBuilder<expressions::Sqrt> sqrt;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Square.h
+++ b/include/vctr/Expressions/BasicMath/Square.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -81,7 +81,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -90,6 +90,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Square> square;
+constexpr inline ExpressionChainBuilder<expressions::Square> square;
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Subtract.h
+++ b/include/vctr/Expressions/BasicMath/Subtract.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 //==============================================================================
@@ -202,7 +202,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -219,7 +219,7 @@ constexpr auto operator- (SrcAType&& a, SrcBType&& b)
     assertCommonSize (a, b);
     constexpr auto extent = getCommonExtent<SrcAType, SrcBType>();
 
-    return Expressions::SubtractVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
+    return expressions::SubtractVectors<extent, SrcAType, SrcBType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b));
 }
 
 /** Returns an expression that subtracts a vector or expression source from a single value.
@@ -230,7 +230,7 @@ template <class Src>
 requires is::anyVctrOrExpression<Src>
 constexpr auto operator- (typename std::remove_cvref_t<Src>::value_type single, Src&& vec)
 {
-    return Expressions::SubtractVecFromSingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::SubtractVecFromSingle<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 /** Returns an expression that subtracts a single value from a vector or expression.
@@ -241,7 +241,7 @@ template <class Src>
 requires is::anyVctrOrExpression<Src>
 constexpr auto operator- (Src&& vec, typename std::remove_cvref_t<Src>::value_type single)
 {
-    return Expressions::SubtractSingleFromVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
+    return expressions::SubtractSingleFromVec<extentOf<Src>, Src> (single, std::forward<Src> (vec));
 }
 
 } // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Sum.h
+++ b/include/vctr/Expressions/BasicMath/Sum.h
@@ -36,7 +36,7 @@ struct SumInit<StringType>
 };
 }
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -104,7 +104,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -113,6 +113,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Sum> sum;
+constexpr inline ExpressionChainBuilder<expressions::Sum> sum;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Complex/Angle.h
+++ b/include/vctr/Expressions/Complex/Angle.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
   template <size_t extent, class SrcType>
@@ -52,7 +52,7 @@ namespace vctr::Expressions
       }
   };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -64,6 +64,6 @@ namespace vctr
 
     @ingroup Expressions
 */
-constexpr inline ExpressionChainBuilder<Expressions::Angle> angle;
+constexpr inline ExpressionChainBuilder<expressions::Angle> angle;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Complex/Conjugate.h
+++ b/include/vctr/Expressions/Complex/Conjugate.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -52,7 +52,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -62,6 +62,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Conjugate> conjugate;
+constexpr inline ExpressionChainBuilder<expressions::Conjugate> conjugate;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Complex/Imag.h
+++ b/include/vctr/Expressions/Complex/Imag.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -45,7 +45,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -57,6 +57,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Imag> imag;
+constexpr inline ExpressionChainBuilder<expressions::Imag> imag;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Complex/PowerSpectrum.h
+++ b/include/vctr/Expressions/Complex/PowerSpectrum.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
   template <size_t extent, class SrcType>
@@ -52,7 +52,7 @@ namespace vctr::Expressions
       }
   };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -69,6 +69,6 @@ namespace vctr
 
     @ingroup Expressions
 */
-constexpr inline ExpressionChainBuilder<Expressions::PowerSpectrum> powerSpectrum;
+constexpr inline ExpressionChainBuilder<expressions::PowerSpectrum> powerSpectrum;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Complex/Real.h
+++ b/include/vctr/Expressions/Complex/Real.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -45,7 +45,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -57,6 +57,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Real> real;
+constexpr inline ExpressionChainBuilder<expressions::Real> real;
 
 } // namespace vctr

--- a/include/vctr/Expressions/DSP/Decibels.h
+++ b/include/vctr/Expressions/DSP/Decibels.h
@@ -30,7 +30,7 @@ struct InvertedConstant
 
 } // namespace vctr::detail
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType, class DecibelConstant, class MinDb>
@@ -48,7 +48,7 @@ using DBToMag = PowConstantBase<extent,
                                                       detail::InvertedConstant<DecibelConstant>>,
                                 Constant<10>>;
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -82,7 +82,7 @@ struct dBPower : Constant<10> {};
    @ingroup Expressions
  */
 template <is::constant DecibelConstant, auto minDb = -100>
-constexpr inline ExpressionChainBuilder<Expressions::MagToDb, DecibelConstant, Constant<minDb>> magToDb;
+constexpr inline ExpressionChainBuilder<expressions::MagToDb, DecibelConstant, Constant<minDb>> magToDb;
 
 /** Converts the source decibel values into their magnitude representation.
 
@@ -94,6 +94,6 @@ constexpr inline ExpressionChainBuilder<Expressions::MagToDb, DecibelConstant, C
    @ingroup Expressions
  */
 template <is::constant DecibelConstant>
-constexpr inline ExpressionChainBuilder<Expressions::DBToMag, DecibelConstant> dbToMag;
+constexpr inline ExpressionChainBuilder<expressions::DBToMag, DecibelConstant> dbToMag;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Exp/Exp.h
+++ b/include/vctr/Expressions/Exp/Exp.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -72,7 +72,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -81,6 +81,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Exp> exp;
+constexpr inline ExpressionChainBuilder<expressions::Exp> exp;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Exp/Ln.h
+++ b/include/vctr/Expressions/Exp/Ln.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -72,7 +72,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -81,6 +81,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Ln> ln;
+constexpr inline ExpressionChainBuilder<expressions::Ln> ln;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Exp/Log10.h
+++ b/include/vctr/Expressions/Exp/Log10.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -72,7 +72,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -81,6 +81,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Log10> log10;
+constexpr inline ExpressionChainBuilder<expressions::Log10> log10;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Exp/Log2.h
+++ b/include/vctr/Expressions/Exp/Log2.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -79,7 +79,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -88,6 +88,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::Log2> log2;
+constexpr inline ExpressionChainBuilder<expressions::Log2> log2;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Exp/Pow.h
+++ b/include/vctr/Expressions/Exp/Pow.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcAType, class SrcBType>
@@ -198,7 +198,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -213,7 +213,7 @@ namespace vctr
     assertCommonSize (bases, exponents);
     constexpr auto extent = getCommonExtent<SrcBaseType, SrcExpType>();
 
-    return Expressions::PowVectors<extent, SrcBaseType, SrcExpType> (std::forward<SrcBaseType> (bases), std::forward<SrcExpType> (exponents));
+    return expressions::PowVectors<extent, SrcBaseType, SrcExpType> (std::forward<SrcBaseType> (bases), std::forward<SrcExpType> (exponents));
 }
 
 /** Returns an expression that raises the base value base to the power of the elements in exponents.
@@ -223,7 +223,7 @@ namespace vctr
 template <is::anyVctrOrExpression Src>
 constexpr auto pow (typename std::remove_cvref_t<Src>::value_type base, Src&& exponents)
 {
-    return Expressions::PowSingleBase<extentOf<Src>, Src> (base, exponents);
+    return expressions::PowSingleBase<extentOf<Src>, Src> (base, exponents);
 }
 
 /** Returns an expression that raises the elements in bases to the power of the exponent value.
@@ -239,7 +239,7 @@ constexpr auto pow (typename std::remove_cvref_t<Src>::value_type base, Src&& ex
 template <is::anyVctrOrExpression Src>
 constexpr auto pow (Src&& bases, typename std::remove_cvref_t<Src>::value_type exponent)
 {
-    return Expressions::PowSingleExponent<extentOf<Src>, Src> (exponent, bases);
+    return expressions::PowSingleExponent<extentOf<Src>, Src> (exponent, bases);
 }
 
 /** Evaluates base raised to the power of the source elements.
@@ -247,13 +247,13 @@ constexpr auto pow (Src&& bases, typename std::remove_cvref_t<Src>::value_type e
     @ingroup Expressions
  */
 template <auto base>
-constexpr inline ExpressionChainBuilder<Expressions::PowConstantBase, Constant<base>> powConstantBase;
+constexpr inline ExpressionChainBuilder<expressions::PowConstantBase, Constant<base>> powConstantBase;
 
 /** Evaluates the source elements raised to the power of exponent.
 
     @ingroup Expressions
  */
 template <auto exponent>
-constexpr inline ExpressionChainBuilder<Expressions::PowConstantExponent, Constant<exponent>> powConstantExponent;
+constexpr inline ExpressionChainBuilder<expressions::PowConstantExponent, Constant<exponent>> powConstantExponent;
 
 } // namespace vctr

--- a/include/vctr/Expressions/ExpressionTemplate.h
+++ b/include/vctr/Expressions/ExpressionTemplate.h
@@ -137,6 +137,12 @@ void tryApplyingRuntimeArgsToThisExpression (const RuntimeArgs& args, Expression
                         e.applyRuntimeArgs (args...);
                     }, args.template get<i>());
     }
+    else if constexpr (has::applyRuntimeArgs<Expression>)
+    {
+        // Some expressions need to initialize runtime values that depend on their source before every
+        // evaluation rather than being injected as external arguments (see e.g. NormalizeSum).
+        e.applyRuntimeArgs();
+    }
 }
 
 template <size_t i, class RuntimeArgs, is::anyVctrOrExpression Src>

--- a/include/vctr/Expressions/Filter/NoAcceleration.h
+++ b/include/vctr/Expressions/Filter/NoAcceleration.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -37,7 +37,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -47,6 +47,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::NoAccelerationFilter> dontUseAcceleration;
+constexpr inline ExpressionChainBuilder<expressions::NoAccelerationFilter> dontUseAcceleration;
 
 }

--- a/include/vctr/Expressions/Filter/PlatformVectorOpsFilter.h
+++ b/include/vctr/Expressions/Filter/PlatformVectorOpsFilter.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -50,7 +50,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -63,6 +63,6 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::PlatformVectorOpsFilter> usePlatformVectorOps;
+constexpr inline ExpressionChainBuilder<expressions::PlatformVectorOpsFilter> usePlatformVectorOps;
 
 } // namespace vctr

--- a/include/vctr/Expressions/Filter/SIMDFilter.h
+++ b/include/vctr/Expressions/Filter/SIMDFilter.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
@@ -92,7 +92,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -103,7 +103,7 @@ namespace vctr
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::SSEFilter> useSSE;
+constexpr inline ExpressionChainBuilder<expressions::SSEFilter> useSSE;
 
 /** This filter expression ensures that only AVX based accelerated evaluation of the previous expression is possible.
 
@@ -111,7 +111,7 @@ constexpr inline ExpressionChainBuilder<Expressions::SSEFilter> useSSE;
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::AVXFilter> useAVX;
+constexpr inline ExpressionChainBuilder<expressions::AVXFilter> useAVX;
 
 /** This filter expression ensures that only Neon based accelerated evaluation of the previous expression is possible.
 
@@ -119,13 +119,13 @@ constexpr inline ExpressionChainBuilder<Expressions::AVXFilter> useAVX;
 
     @ingroup Expressions
  */
-constexpr inline ExpressionChainBuilder<Expressions::NeonFilter> useNeon;
+constexpr inline ExpressionChainBuilder<expressions::NeonFilter> useNeon;
 
 #if VCTR_ARM
 constexpr inline ExpressionChainBuilder<Expressions::NeonFilter> useNeonOrAVX;
 constexpr inline ExpressionChainBuilder<Expressions::NeonFilter> useNeonOrSSE;
 #else
-constexpr inline ExpressionChainBuilder<Expressions::AVXFilter> useNeonOrAVX;
-constexpr inline ExpressionChainBuilder<Expressions::SSEFilter> useNeonOrSSE;
+constexpr inline ExpressionChainBuilder<expressions::AVXFilter> useNeonOrAVX;
+constexpr inline ExpressionChainBuilder<expressions::SSEFilter> useNeonOrSSE;
 #endif
 } // namespace vctr

--- a/include/vctr/Expressions/Generic/Map.h
+++ b/include/vctr/Expressions/Generic/Map.h
@@ -1,0 +1,257 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr::expressions
+{
+
+template <size_t extent, class SrcType, is::rangeWithValueType<ValueType<SrcType>> RangeType>
+requires is::floatNumber<ValueType<SrcType>>
+class Map : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcType>;
+    
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (Map, src)
+
+    void applyRuntimeArgs (RangeType newSrcRange, RangeType newDstRange)
+    {
+        srcRangeStartNegated = -newSrcRange.getStart();
+        srcDstLenRatio = newDstRange.getLength() / newSrcRange.getLength();
+        dstRangeStart = newDstRange.getStart();
+    }
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+        return (src[i] + srcRangeStartNegated) * srcDstLenRatio + dstRangeStart;
+    }
+
+    //==============================================================================
+    // Platform Vector Operation Implementation
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable>
+    {
+        const auto s = size();
+
+        Expression::Accelerate::add (src.evalNextVectorOpInExpressionChain (dst), srcRangeStartNegated, dst, s);
+        Expression::Accelerate::mul (dst, srcDstLenRatio, dst, s);
+        Expression::Accelerate::add (dst, dstRangeStart, dst, s);
+
+        return dst;
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealFloatVectorOp<SrcType, value_type, detail::preferIfIppAndAccelerateAreAvailable>
+    {
+        const auto s = size();
+
+        Expression::IPP::add (src.evalNextVectorOpInExpressionChain (dst), srcRangeStartNegated, dst, s);
+        Expression::IPP::mul (dst, srcDstLenRatio, dst, s);
+        Expression::IPP::add (dst, dstRangeStart, dst, s);
+
+        return dst;
+    }
+
+private:
+    //==============================================================================
+    value_type srcRangeStartNegated = 0;
+    value_type srcDstLenRatio = 0;
+    value_type dstRangeStart = 0;
+};
+
+template <size_t extent, class SrcType, is::rangeWithValueType<ValueType<SrcType>> RangeType>
+requires is::floatNumber<ValueType<SrcType>>
+class MapFrom0To1 : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcType>;
+
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (MapFrom0To1, src)
+
+    void applyRuntimeArgs (RangeType newDstRange)
+    {
+        dstRangeStart = newDstRange.getStart();
+        dstRangeLen = newDstRange.getLength();
+    }
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+        return src[i] * dstRangeLen + dstRangeStart;
+    }
+
+    //==============================================================================
+    // Platform Vector Operation Implementation
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable>
+    {
+        const auto s = size();
+
+        Expression::Accelerate::mul (src.evalNextVectorOpInExpressionChain (dst), dstRangeLen, dst, s);
+        Expression::Accelerate::add (dst, dstRangeStart, dst, s);
+
+        return dst;
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealFloatVectorOp<SrcType, value_type, detail::preferIfIppAndAccelerateAreAvailable>
+    {
+        const auto s = size();
+
+        Expression::IPP::mul (src.evalNextVectorOpInExpressionChain (dst), dstRangeLen, dst, s);
+        Expression::IPP::add (dst, dstRangeStart, dst, s);
+
+        return dst;
+    }
+
+private:
+    //==============================================================================
+    value_type dstRangeStart = 0;
+    value_type dstRangeLen = 0;
+};
+
+template <size_t extent, class SrcType, is::rangeWithValueType<ValueType<SrcType>> RangeType>
+requires is::floatNumber<ValueType<SrcType>>
+class MapTo0To1 : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcType>;
+
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (MapTo0To1, src)
+
+    void applyRuntimeArgs (RangeType newSrcRange)
+    {
+        srcRangeStartNegated = -newSrcRange.getStart();
+        srcRangeLen = newSrcRange.getLength();
+    }
+
+    VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
+    {
+        return (src[i] + srcRangeStartNegated) / srcRangeLen;
+    }
+
+    //==============================================================================
+    // Platform Vector Operation Implementation
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable>
+    {
+        const auto s = size();
+
+        Expression::Accelerate::add (src.evalNextVectorOpInExpressionChain (dst), srcRangeStartNegated, dst, s);
+        Expression::Accelerate::div (dst, srcRangeLen, dst, s);
+
+        return dst;
+    }
+
+    VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
+    requires is::suitableForIppRealFloatVectorOp<SrcType, value_type, detail::preferIfIppAndAccelerateAreAvailable>
+    {
+        const auto s = size();
+
+        Expression::IPP::add (src.evalNextVectorOpInExpressionChain (dst), srcRangeStartNegated, dst, s);
+        Expression::IPP::div (dst, srcRangeLen, dst, s);
+
+        return dst;
+    }
+
+private:
+    //==============================================================================
+    value_type srcRangeStartNegated = 0;
+    value_type srcRangeLen = 0;
+};
+
+} // namespace vctr::expressions
+
+namespace vctr
+{
+
+/** Maps all source element values from srcValueRange to values in dstValueRange.
+
+    The expression does not check if the source values are actually in the expected range.
+
+    @ingroup Expressions
+ */
+template <is::range RangeType>
+auto map (RangeType&& srcValueRange, RangeType&& dstValueRange)
+{
+    return makeTemplateExpressionChainBuilderWithRuntimeArgs<expressions::Map, std::remove_cvref_t<RangeType>> (std::forward<RangeType> (srcValueRange), std::forward<RangeType> (dstValueRange));
+}
+
+/** Maps all source element values from the range srcValueRangeStart to srcValueRangeEnd to values in [dstValueRangeStart, dstValueRangeEnd].
+
+    The expression does not check if the source values are actually in the expected range.
+
+    @ingroup Expressions
+ */
+template <is::floatNumber T>
+auto map (T srcValueRangeStart, T srcValueRangeEnd, T dstValueRangeStart, T dstValueRangeEnd)
+{
+    return map (Range (srcValueRangeStart, srcValueRangeEnd), Range (dstValueRangeStart, dstValueRangeEnd));
+}
+
+/** Maps all source element values from the range [0.0 to 1.0] to values in dstValueRange.
+
+    The expression does not check if the source values are actually in the expected range.
+
+    @ingroup Expressions
+ */
+template <is::range RangeType>
+auto mapFrom0To1 (RangeType&& dstValueRange)
+{
+    return makeTemplateExpressionChainBuilderWithRuntimeArgs<expressions::MapFrom0To1, std::remove_cvref_t<RangeType>> (std::forward<RangeType> (dstValueRange));
+}
+
+/** Maps all source element values from the range [0.0 to 1.0] to values in the range from [dstValueRangeStart to dstValueRangeEnd].
+
+    The expression does not check if the source values are actually in the expected range.
+
+    @ingroup Expressions
+ */
+template <is::floatNumber T>
+auto mapFrom0To1 (T dstValueRangeStart, T dstValueRangeEnd)
+{
+    return mapFrom0To1 (vctr::Range (dstValueRangeStart, dstValueRangeEnd));
+}
+
+/** Maps all source element values from srcValueRange to values in the range [0.0 to 1.0].
+
+    The expression does not check if the source values are actually in the expected range.
+
+    @ingroup Expressions
+ */
+template <is::range RangeType>
+auto mapTo0To1 (RangeType&& srcValueRange)
+{
+    return makeTemplateExpressionChainBuilderWithRuntimeArgs<expressions::MapTo0To1, std::remove_cvref_t<RangeType>> (std::forward<RangeType> (srcValueRange));
+}
+
+/** Maps all source element values from teh range [srcValueRangeStart to srcValueRangeEnd] to values in the range [0.0 to 1.0].
+
+    The expression does not check if the source values are actually in the expected range.
+
+    @ingroup Expressions
+ */
+template <is::floatNumber T>
+auto mapTo0To1 (T srcValueRangeStart, T srcValueRangeEnd)
+{
+    return mapTo0To1 (Range (srcValueRangeStart, srcValueRangeEnd));
+}
+
+}

--- a/include/vctr/Expressions/Generic/TransformedBy.h
+++ b/include/vctr/Expressions/Generic/TransformedBy.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType, std::invocable<ValueType<SrcType>> FunctionType>
@@ -47,7 +47,7 @@ private:
     FnCopyType fn;
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -67,7 +67,7 @@ namespace vctr
 template <class Fn>
 constexpr auto transformedBy (Fn&& fn)
 {
-    return makeTemplateExpressionChainBuilderWithRuntimeArgs<Expressions::TransformedBy, std::remove_cvref_t<Fn>> (std::forward<Fn> (fn));
+    return makeTemplateExpressionChainBuilderWithRuntimeArgs<expressions::TransformedBy, std::remove_cvref_t<Fn>> (std::forward<Fn> (fn));
 }
 
 } // namespace vctr

--- a/include/vctr/Expressions/Generic/TransformedByStaticCast.h
+++ b/include/vctr/Expressions/Generic/TransformedByStaticCast.h
@@ -20,7 +20,7 @@
   ==============================================================================
 */
 
-namespace vctr::Expressions
+namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType, std::constructible_from<ValueType<SrcType>> DstValueType>
@@ -55,7 +55,7 @@ public:
     }
 };
 
-} // namespace vctr::Expressions
+} // namespace vctr::expressions
 
 namespace vctr
 {
@@ -64,7 +64,7 @@ namespace vctr
     @ingroup Expressions
  */
 template <class DstType>
-constexpr inline ExpressionChainBuilder<Expressions::TransformedByStaticCast, DstType> transformedByStaticCastTo;
+constexpr inline ExpressionChainBuilder<expressions::TransformedByStaticCast, DstType> transformedByStaticCastTo;
 
 } // namespace vctr
 

--- a/include/vctr/Miscellaneous/Range.h
+++ b/include/vctr/Miscellaneous/Range.h
@@ -1,0 +1,88 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr
+{
+
+/** A simple range class.
+
+    The interface is intended to be compatible with the juce::Range class.
+ */
+template <is::realNumber ValueType>
+class Range
+{
+public:
+    using value_type = ValueType;
+
+    //==============================================================================
+    /** Constructs a range with given start and end values.
+
+        The end value must not be smaller than the start value.
+     */
+    constexpr Range (ValueType startValue, ValueType endValue) noexcept
+        : start (startValue),
+          end (endValue)
+    {
+        VCTR_ASSERT (end >= start);
+    }
+
+    /** Constructs an empty range. */
+    constexpr Range() = default;
+
+    /** Copy constructor. */
+    constexpr Range (const Range&) = default;
+
+    /** Move constructor. */
+    constexpr Range (Range&&) = default;
+
+    //==============================================================================
+    /** Sets a new start value. */
+    constexpr void setStart (ValueType newStart) noexcept
+    {
+        start = newStart;
+        VCTR_ASSERT (start <= end);
+    }
+
+    /** Sets a new end value. */
+    constexpr void setEnd (ValueType newEnd) noexcept
+    {
+        end = newEnd;
+        VCTR_ASSERT (start <= end);
+    }
+
+    //==============================================================================
+    /** Returns the start of the range. */
+    constexpr ValueType getStart() const noexcept          { return start; }
+
+    /** Returns the length of the range. */
+    constexpr ValueType getLength() const noexcept         { return end - start; }
+
+    /** Returns the end of the range. */
+    constexpr ValueType getEnd() const noexcept            { return end; }
+
+private:
+    //==============================================================================
+    ValueType start { 0 };
+    ValueType end { 0 };
+};
+
+}

--- a/include/vctr/TypeTraitsAndConcepts/GenericConcepts.h
+++ b/include/vctr/TypeTraitsAndConcepts/GenericConcepts.h
@@ -27,8 +27,33 @@ namespace vctr::has
 template <class Lhs, class Rhs = Lhs>
 concept operatorPlusEquals = requires (Lhs l, Rhs r) { l += r; };
 
+/** Constrains the type to have a member function init that takes a void pointer and a size_t. */
 template <class T>
 concept init = requires (T& t, void* ptr, size_t s) { t.init (ptr, s); };
+
+/** Constrains the type to have a member function function getStart() const which returns a real number. */
+template <class T>
+concept getStart = requires (const T& t) { { t.getStart() } -> is::realNumber; };
+
+/** Constrains the type to have a member function function getLength() const which returns a real number. */
+template <class T>
+concept getLength = requires (const T& t) { { t.getLength() } -> is::realNumber; };
+
+/** Constrains the type to have a member function function getEnd() const which returns a real number. */
+template <class T>
+concept getEnd = requires (const T& t) { { t.getEnd() } -> is::realNumber; };
+
+/** Constrains the type to have a member function function getStart() const which returns ValueType. */
+template <class T, class ValueType>
+concept getStartWithValueType = requires (const T& t) { { t.getStart() } -> std::same_as<ValueType>; };
+
+/** Constrains the type to have a member function function getLength() const which returns ValueType. */
+template <class T, class ValueType>
+concept getLengthWithValueType = requires (const T& t) { { t.getLength() } -> std::same_as<ValueType>; };
+
+/** Constrains the type to have a member function function getEnd() const which returns ValueType. */
+template <class T, class ValueType>
+concept getEndWithValueType = requires (const T& t) { { t.getEnd() } -> std::same_as<ValueType>; };
 
 }
 
@@ -53,8 +78,6 @@ struct IsStdTuple<std::tuple<T...>> : std::true_type {};
 
 namespace vctr::is
 {
-
-// clang-format off
 
 /** Constrains a type to be trivially copyable */
 template <class T>
@@ -97,7 +120,17 @@ concept constant = requires (const void* ptr) { ptr = &C::value; };
 template <class C, class T>
 concept constantWithType = std::same_as<T, std::remove_cvref_t<decltype (C::value)>>;
 
-// clang-format on
+/** Constrains the type to be a range, this is a class with a getStart, getLength and getEnd member function returning a real number. */
+template <class T>
+concept range = has::getStart<T> &&
+                has::getLength<T> &&
+                has::getEnd<T>;
+
+/** Constrains the type to be a range, this is a class with a getStart, getLength and getEnd member function returning ValueType. */
+template <class T, class ValueType>
+concept rangeWithValueType = has::getStartWithValueType<T, ValueType> &&
+                             has::getLengthWithValueType<T, ValueType> &&
+                             has::getEndWithValueType<T, ValueType>;
 
 } // namespace vctr::is
 

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -170,6 +170,7 @@
 #include "Expressions/BasicMath/Min.h"
 #include "Expressions/BasicMath/Mean.h"
 #include "Expressions/BasicMath/Sum.h"
+#include "Expressions/BasicMath/NormalizeSum.h"
 
 #include "Expressions/Complex/Angle.h"
 #include "Expressions/Complex/Conjugate.h"

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -153,6 +153,7 @@
 #include "Expressions/Filter/SIMDFilter.h"
 #include "Expressions/Filter/PlatformVectorOpsFilter.h"
 
+#include "Expressions/Generic/Map.h"
 #include "Expressions/Generic/TransformedBy.h"
 #include "Expressions/Generic/TransformedByStaticCast.h"
 

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -120,7 +120,6 @@
     used to initialize a new Vector or Array.
  */
 
-#include "TypeTraitsAndConcepts/NumericTypeConcepts.h"
 #include "TypeTraitsAndConcepts/ContainerAndExpressionConcepts.h"
 #include "TypeTraitsAndConcepts/FunctionConcepts.h"
 
@@ -138,6 +137,8 @@
 #include "TypeTraitsAndConcepts/Traits.h"
 
 #include "Expressions/ExpressionTemplate.h"
+
+#include "Miscellaneous/Range.h"
 
 #include "Containers/VctrBase.h"
 #include "Containers/Span.h"

--- a/include/vctr/vctr_forward_declarations.h
+++ b/include/vctr/vctr_forward_declarations.h
@@ -22,9 +22,15 @@
 
 #pragma once
 
+namespace vctr
+{
+struct DisabledConstant;
+}
+
 #include <complex>
-#include "TypeTraitsAndConcepts/GenericConcepts.h"
 #include "TypeTraitsAndConcepts/NumericValueConcepts.h"
+#include "TypeTraitsAndConcepts/NumericTypeConcepts.h"
+#include "TypeTraitsAndConcepts/GenericConcepts.h"
 
 /** The main namespace of the VCTR project. */
 namespace vctr
@@ -63,6 +69,4 @@ struct SSERegister;
 
 template <class T>
 struct NeonRegister;
-
-struct DisabledConstant;
 } // namespace vctr

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources (vctr_test PRIVATE
         TestCases/ConversionOperators.cpp
         TestCases/ElementAccessFunctions.cpp
         TestCases/FindingAndManipulatingElements.cpp
+        TestCases/Range.cpp
         TestCases/SpanConstructors.cpp
         TestCases/SpanMemberFunctions.cpp
         TestCases/VctrBaseMemberFunctions.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources (vctr_test PRIVATE
         TestCases/Expressions/Max.cpp
         TestCases/Expressions/Mean.cpp
         TestCases/Expressions/Min.cpp
+        TestCases/Expressions/NormalizeSum.cpp
         TestCases/Expressions/Pow.cpp
         TestCases/Expressions/PowerSpectrum.cpp
         TestCases/Expressions/RealImag.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources (vctr_test PRIVATE
         TestCases/Expressions/Log10.cpp
         TestCases/Expressions/Decibels.cpp
         TestCases/Expressions/Multiply.cpp
+        TestCases/Expressions/Map.cpp
         TestCases/Expressions/Max.cpp
         TestCases/Expressions/Mean.cpp
         TestCases/Expressions/Min.cpp

--- a/test/TestCases/Expressions/Map.cpp
+++ b/test/TestCases/Expressions/Map.cpp
@@ -1,0 +1,93 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+template <int srcMin, int srcMax, int dstMin, int dstMax, vctr::is::realNumber T>
+T map (T val)
+{
+    val -= T (srcMin);
+    val *= T (dstMax - dstMin);
+    val /= T (srcMax - srcMin);
+    val += T (dstMin);
+    return val;
+}
+
+TEMPLATE_PRODUCT_TEST_CASE ("Map", "[expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+{
+    constexpr int srcValueMin = -52;
+    constexpr int srcValueMax = 4000;
+
+    constexpr int dstValueMin = -70123;
+    constexpr int dstValueMax = -2;
+
+    VCTR_TEST_DEFINES_IN_RANGE (srcValueMin, srcValueMax, 10)
+
+    vctr::Vector mapped1 = filter << vctr::map (ElementType (srcValueMin), ElementType (srcValueMax), ElementType (dstValueMin), ElementType (dstValueMax)) << srcA;
+    vctr::Vector mapped2 = filter << vctr::map (vctr::Range<ElementType> (srcValueMin, srcValueMax), vctr::Range<ElementType> (dstValueMin, dstValueMax)) << srcA;
+
+    REQUIRE_THAT (mapped1, vctr::Equals (mapped2));
+    REQUIRE (mapped1.min() >= ElementType (dstValueMin));
+    REQUIRE (mapped1.max() <= ElementType (dstValueMax));
+
+    REQUIRE_THAT (mapped1, (vctr::EqualsTransformedBy<map<srcValueMin, srcValueMax, dstValueMin, dstValueMax>> (srcA).withEpsilon (0.0001)));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE ("MapFrom0To1", "[expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+{
+    constexpr int srcValueMin = 0;
+    constexpr int srcValueMax = 1;
+
+    constexpr int dstValueMin = -70123;
+    constexpr int dstValueMax = -2;
+
+    VCTR_TEST_DEFINES_IN_RANGE (srcValueMin, srcValueMax, 10)
+
+    vctr::Vector mapped1 = filter << vctr::mapFrom0To1 (ElementType (dstValueMin), ElementType (dstValueMax)) << srcA;
+    vctr::Vector mapped2 = filter << vctr::mapFrom0To1 (vctr::Range<ElementType> (dstValueMin, dstValueMax)) << srcA;
+
+    REQUIRE_THAT (mapped1, vctr::Equals (mapped2));
+    REQUIRE (mapped1.min() >= ElementType (dstValueMin));
+    REQUIRE (mapped1.max() <= ElementType (dstValueMax));
+
+    REQUIRE_THAT (mapped1, (vctr::EqualsTransformedBy<map<srcValueMin, srcValueMax, dstValueMin, dstValueMax>> (srcA).withEpsilon (0.00001)));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE ("MapTo0To1", "[expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+{
+    constexpr int srcValueMin = -52;
+    constexpr int srcValueMax = 4000;
+
+    constexpr int dstValueMin = 0;
+    constexpr int dstValueMax = 1;
+
+    VCTR_TEST_DEFINES_IN_RANGE (srcValueMin, srcValueMax, 10)
+
+    vctr::Vector mapped1 = filter << vctr::mapTo0To1 (ElementType (srcValueMin), ElementType (srcValueMax)) << srcA;
+    vctr::Vector mapped2 = filter << vctr::mapTo0To1 (vctr::Range<ElementType> (srcValueMin, srcValueMax)) << srcA;
+
+    REQUIRE_THAT (mapped1, vctr::Equals (mapped2));
+    REQUIRE (mapped1.min() >= ElementType (dstValueMin));
+    REQUIRE (mapped1.max() <= ElementType (dstValueMax));
+
+    REQUIRE_THAT (mapped1, (vctr::EqualsTransformedBy<map<srcValueMin, srcValueMax, dstValueMin, dstValueMax>> (srcA).withEpsilon (0.00001)));
+}

--- a/test/TestCases/Expressions/NormalizeSum.cpp
+++ b/test/TestCases/Expressions/NormalizeSum.cpp
@@ -1,0 +1,38 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+TEMPLATE_PRODUCT_TEST_CASE ("NormalizeSum", "[expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+{
+    VCTR_TEST_DEFINES (10)
+
+    vctr::Vector normalizedSum = filter << vctr::normalizeSum << (srcA + ElementType (1));
+
+    vctr::Vector srcAPlus1 = srcA + ElementType (1);
+
+    const auto sum = vctr::sum << srcAPlus1;
+
+    vctr::Vector dividedBySum = srcAPlus1 / sum;
+
+    REQUIRE_THAT (normalizedSum, vctr::Equals (dividedBySum).withEpsilon (0.000001));
+}

--- a/test/TestCases/Range.cpp
+++ b/test/TestCases/Range.cpp
@@ -1,0 +1,49 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2023 by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+TEMPLATE_TEST_CASE ("Range", "[range]", float, double, int)
+{
+    auto a = UnitTestValues<TestType>::template array<2, 0>();
+    a.sort();
+
+    vctr::Range r (a[0], a[1]);
+
+    REQUIRE (r.getStart() == a[0]);
+    REQUIRE (r.getEnd() == a[1]);
+    REQUIRE (r.getLength() == a[1] - a[0]);
+
+    a -= TestType (2);
+
+    r.setStart (a[0]);
+    r.setEnd (a[1]);
+
+    REQUIRE (r.getStart() == a[0]);
+    REQUIRE (r.getEnd() == a[1]);
+    REQUIRE (r.getLength() == a[1] - a[0]);
+
+    vctr::Range<TestType> empty;
+    REQUIRE (empty.getStart() == TestType (0));
+    REQUIRE (empty.getEnd() == TestType (0));
+    REQUIRE (empty.getLength() == TestType (0));
+}


### PR DESCRIPTION
Note: This includes all the commits from https://github.com/sonible/VCTR/pull/87 since the unit tests use the `sort` function implemented there. Should be rebased on develop as soon as the other PR has been merged