### PR TITLE
NumericTypeConcepts: Reworked floating point number concepts

### DIFF
--- a/include/vctr/Containers/VctrBase.h
+++ b/include/vctr/Containers/VctrBase.h
@@ -949,7 +949,7 @@ protected:
 
             if constexpr (has::getAVX<Expression>)
             {
-                if constexpr (is::floatNumber<ElementType>)
+                if constexpr (is::realFloatNumber<ElementType>)
                 {
                     if (supportsAVX)
                     {

--- a/include/vctr/Expressions/BasicMath/Abs.h
+++ b/include/vctr/Expressions/BasicMath/Abs.h
@@ -79,7 +79,7 @@ public:
 
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::CommonElement::isRealFloat)
     {
         static const auto avxSignBit = Expression::AVX::broadcast (typename Expression::CommonElement::Type (-0.0));
 
@@ -100,7 +100,7 @@ public:
 
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires (archX64 && has::getSSE<SrcType> && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getSSE<SrcType> && Expression::CommonElement::isRealFloat)
     {
         static const auto sseSignBit = Expression::SSE::broadcast (typename Expression::CommonElement::Type (-0.0));
 

--- a/include/vctr/Expressions/BasicMath/Add.h
+++ b/include/vctr/Expressions/BasicMath/Add.h
@@ -55,7 +55,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::add (srcA.getAVX (i), srcB.getAVX (i));
     }
@@ -107,7 +107,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::add (Expression::AVX::fromSSE (singleAsSSE, singleAsSSE), src.getAVX (i));
     }

--- a/include/vctr/Expressions/BasicMath/Cube.h
+++ b/include/vctr/Expressions/BasicMath/Cube.h
@@ -40,7 +40,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires archX64 && has::getAVX<SrcType> && Expression::CommonElement::isFloatingPoint
+    requires archX64 && has::getAVX<SrcType> && Expression::CommonElement::isRealFloat
     {
         auto x = src.getAVX (i);
         auto y = Expression::AVX::mul (x, x);
@@ -50,7 +50,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires archX64 && has::getSSE<SrcType> && Expression::CommonElement::isFloatingPoint
+    requires archX64 && has::getSSE<SrcType> && Expression::CommonElement::isRealFloat
     {
         auto x = src.getSSE (i);
         auto y = Expression::SSE::mul (x, x);
@@ -60,7 +60,7 @@ public:
     //==============================================================================
     // Neon Implementation
     NeonRegister<value_type> getNeon (size_t i) const
-    requires archARM && has::getNeon<SrcType> && (Expression::CommonElement::isFloatingPoint || Expression::CommonElement::isInt32 || Expression::CommonElement::isUint32)
+    requires archARM && has::getNeon<SrcType> && (Expression::CommonElement::isRealFloat || Expression::CommonElement::isInt32 || Expression::CommonElement::isUint32)
     {
         auto x = src.getNeon (i);
         auto y = Expression::Neon::mul (x, x);

--- a/include/vctr/Expressions/BasicMath/Divide.h
+++ b/include/vctr/Expressions/BasicMath/Divide.h
@@ -55,7 +55,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::div (srcA.getAVX (i), srcB.getAVX (i));
     }
@@ -63,7 +63,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires (archX64 && has::getSSE<SrcAType> && has::getSSE<SrcBType> && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getSSE<SrcAType> && has::getSSE<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::SSE::div (srcA.getSSE (i), srcB.getSSE (i));
     }
@@ -94,7 +94,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::div (Expression::AVX::fromSSE (singleAsSSE, singleAsSSE), src.getAVX (i));
     }
@@ -102,7 +102,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::SSE::div (singleAsSSE, src.getSSE (i));
     }
@@ -140,7 +140,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::div (src.getAVX (i), Expression::AVX::fromSSE (singleAsSSE, singleAsSSE));
     }
@@ -148,7 +148,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::SSE::div (src.getSSE (i), singleAsSSE);
     }

--- a/include/vctr/Expressions/BasicMath/Max.h
+++ b/include/vctr/Expressions/BasicMath/Max.h
@@ -54,13 +54,13 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::Neon::max (result, src.getNeon (i));
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::max (result, src.getAVX (i));
     }
@@ -72,7 +72,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archX64 && has::getSSE<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::SSE::max (result, src.getSSE (i));
     }
@@ -120,7 +120,7 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || std::same_as<int32_t, value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || std::same_as<int32_t, value_type>)
     {
         result = Expression::Neon::max (result, Expression::Neon::abs (src.getNeon (i)));
     }
@@ -132,7 +132,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         static const auto avxSignBit = Expression::AVX::broadcast (typename Expression::CommonElement::Type (-0.0));
 
@@ -152,7 +152,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getSSE<SrcType> && is::realFloatNumber<value_type>
     {
         static const auto sseSignBit = Expression::SSE::broadcast (typename Expression::CommonElement::Type (-0.0));
 

--- a/include/vctr/Expressions/BasicMath/Mean.h
+++ b/include/vctr/Expressions/BasicMath/Mean.h
@@ -54,13 +54,13 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::Neon::add (result, src.getNeon (i));
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::add (result, src.getAVX (i));
     }
@@ -72,7 +72,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archX64 && has::getSSE<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::SSE::add (result, src.getSSE (i));
     }
@@ -120,7 +120,7 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         auto s = src.getNeon (i);
         s = Expression::Neon::mul (s, s);
@@ -128,7 +128,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         auto s = src.getAVX (i);
         s = Expression::AVX::mul (s, s);
@@ -136,7 +136,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getSSE<SrcType> && is::realFloatNumber<value_type>
     {
         auto s = src.getSSE (i);
         s = Expression::SSE::mul (s, s);
@@ -186,7 +186,7 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         auto s = src.getNeon (i);
         s = Expression::Neon::mul (s, s);
@@ -194,7 +194,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         auto s = src.getAVX (i);
         s = Expression::AVX::mul (s, s);
@@ -202,7 +202,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getSSE<SrcType> && is::realFloatNumber<value_type>
     {
         auto s = src.getSSE (i);
         s = Expression::SSE::mul (s, s);

--- a/include/vctr/Expressions/BasicMath/Min.h
+++ b/include/vctr/Expressions/BasicMath/Min.h
@@ -54,13 +54,13 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::Neon::min (result, src.getNeon (i));
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::min (result, src.getAVX (i));
     }
@@ -72,7 +72,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archX64 && has::getSSE<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::SSE::min (result, src.getSSE (i));
     }
@@ -120,7 +120,7 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || std::same_as<int32_t, value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || std::same_as<int32_t, value_type>)
     {
         result = Expression::Neon::min (result, Expression::Neon::abs (src.getNeon (i)));
     }
@@ -132,7 +132,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         static const auto avxSignBit = Expression::AVX::broadcast (typename Expression::CommonElement::Type (-0.0));
 
@@ -152,7 +152,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getSSE<SrcType> && is::realFloatNumber<value_type>
     {
         static const auto sseSignBit = Expression::SSE::broadcast (typename Expression::CommonElement::Type (-0.0));
 

--- a/include/vctr/Expressions/BasicMath/Multiply.h
+++ b/include/vctr/Expressions/BasicMath/Multiply.h
@@ -68,7 +68,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::mul (srcA.getAVX (i), srcB.getAVX (i));
     }
@@ -118,7 +118,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::mul (Expression::AVX::fromSSE (singleAsSSE, singleAsSSE), src.getAVX (i));
     }
@@ -126,7 +126,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::SSE::mul (singleAsSSE, src.getSSE (i));
     }
@@ -194,7 +194,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::mul (Expression::AVX::fromSSE (asSSE, asSSE), src.getAVX (i));
     }
@@ -202,7 +202,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::SSE::mul (asSSE, src.getSSE (i));
     }

--- a/include/vctr/Expressions/BasicMath/NormalizeSum.h
+++ b/include/vctr/Expressions/BasicMath/NormalizeSum.h
@@ -24,7 +24,7 @@ namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
-requires is::floatNumber<ValueType<SrcType>>
+requires is::realFloatNumber<ValueType<SrcType>>
 class NormalizeSum : ExpressionTemplateBase
 {
 public:

--- a/include/vctr/Expressions/BasicMath/Sqrt.h
+++ b/include/vctr/Expressions/BasicMath/Sqrt.h
@@ -24,7 +24,7 @@ namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
-requires is::floatNumber<ValueType<SrcType>> || is::complexFloatNumber<ValueType<SrcType>>
+requires is::realFloatNumber<ValueType<SrcType>> || is::complexFloatNumber<ValueType<SrcType>>
 class Sqrt : ExpressionTemplateBase
 {
 public:

--- a/include/vctr/Expressions/BasicMath/Square.h
+++ b/include/vctr/Expressions/BasicMath/Square.h
@@ -65,7 +65,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires archX64 && has::getAVX<SrcType> && Expression::CommonElement::isFloatingPoint
+    requires archX64 && has::getAVX<SrcType> && Expression::CommonElement::isRealFloat
     {
         auto x = src.getAVX (i);
         return Expression::AVX::mul (x, x);
@@ -74,7 +74,7 @@ public:
     //==============================================================================
     // SSE Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-    requires archX64 && has::getSSE<SrcType> && Expression::CommonElement::isFloatingPoint
+    requires archX64 && has::getSSE<SrcType> && Expression::CommonElement::isRealFloat
     {
         auto x = src.getSSE (i);
         return Expression::SSE::mul (x, x);

--- a/include/vctr/Expressions/BasicMath/Subtract.h
+++ b/include/vctr/Expressions/BasicMath/Subtract.h
@@ -55,7 +55,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::sub (srcA.getAVX (i), srcB.getAVX (i));
     }
@@ -116,7 +116,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::sub (Expression::AVX::fromSSE (singleAsSSE, singleAsSSE), src.getAVX (i));
     }
@@ -175,7 +175,7 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloatingPoint)
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::sub (src.getAVX (i), Expression::AVX::fromSSE (singleAsSSE, singleAsSSE));
     }

--- a/include/vctr/Expressions/BasicMath/Sum.h
+++ b/include/vctr/Expressions/BasicMath/Sum.h
@@ -70,13 +70,13 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const
-    requires Config::archARM && has::getNeon<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archARM && has::getNeon<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::Neon::add (result, src.getNeon (i));
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>
+    requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::add (result, src.getAVX (i));
     }
@@ -88,7 +88,7 @@ public:
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void reduceSSERegisterWise (SSERegister<value_type>& result, size_t i) const
-    requires Config::archX64 && has::getSSE<SrcType> && (is::floatNumber<value_type> || is::int32Number<value_type>)
+    requires Config::archX64 && has::getSSE<SrcType> && (is::realFloatNumber<value_type> || is::int32Number<value_type>)
     {
         result = Expression::SSE::add (result, src.getSSE (i));
     }

--- a/include/vctr/Expressions/Complex/Conjugate.h
+++ b/include/vctr/Expressions/Complex/Conjugate.h
@@ -24,7 +24,7 @@ namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType>
-requires is::complexNumber<ValueType<SrcType>>
+requires is::complexFloatNumber<ValueType<SrcType>>
 class Conjugate : public ExpressionTemplateBase
 {
 public:

--- a/include/vctr/Expressions/Exp/Exp.h
+++ b/include/vctr/Expressions/Exp/Exp.h
@@ -47,7 +47,7 @@ public:
     //==============================================================================
     // Platform Vector Operation Implementation
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
-    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable> && is::floatNumber<SrcValueType>
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable> && is::realFloatNumber<SrcValueType>
     {
         Expression::Accelerate::exp (src.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
         return dst;

--- a/include/vctr/Expressions/Exp/Ln.h
+++ b/include/vctr/Expressions/Exp/Ln.h
@@ -47,7 +47,7 @@ public:
     //==============================================================================
     // Platform Vector Operation Implementation
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
-    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable> && is::floatNumber<SrcValueType>
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable> && is::realFloatNumber<SrcValueType>
     {
         Expression::Accelerate::ln (src.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
         return dst;

--- a/include/vctr/Expressions/Exp/Log10.h
+++ b/include/vctr/Expressions/Exp/Log10.h
@@ -47,7 +47,7 @@ public:
     //==============================================================================
     // Platform Vector Operation Implementation
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
-    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable> && is::floatNumber<SrcValueType>
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable> && is::realFloatNumber<SrcValueType>
     {
         Expression::Accelerate::log10 (src.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
         return dst;

--- a/include/vctr/Expressions/Exp/Log2.h
+++ b/include/vctr/Expressions/Exp/Log2.h
@@ -47,7 +47,7 @@ public:
     //==============================================================================
     // Platform Vector Operation Implementation
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
-    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::preferIfIppAndAccelerateAreAvailable> && is::floatNumber<SrcValueType>
+    requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::preferIfIppAndAccelerateAreAvailable> && is::realFloatNumber<SrcValueType>
     {
         Expression::Accelerate::log2 (src.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
         return dst;

--- a/include/vctr/Expressions/Exp/Pow.h
+++ b/include/vctr/Expressions/Exp/Pow.h
@@ -35,7 +35,7 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
 #if VCTR_USE_GCEM
-        if constexpr (! is::complexNumber<value_type>)
+        if constexpr (! is::complexFloatNumber<value_type>)
         {
             if (std::is_constant_evaluated())
                 return gcem::pow (srcBase[i], srcExp[i]);
@@ -85,7 +85,7 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
 #if VCTR_USE_GCEM
-        if constexpr (! is::complexNumber<value_type>)
+        if constexpr (! is::complexFloatNumber<value_type>)
         {
             if (std::is_constant_evaluated())
                 return gcem::pow (base[i], exp);
@@ -114,7 +114,7 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
 #if VCTR_USE_GCEM
-        if constexpr (! is::complexNumber<value_type>)
+        if constexpr (! is::complexFloatNumber<value_type>)
         {
             if (std::is_constant_evaluated())
                 return gcem::pow (base, exp[i]);
@@ -138,7 +138,7 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
 #if VCTR_USE_GCEM
-        if constexpr (! is::complexNumber<value_type>)
+        if constexpr (! is::complexFloatNumber<value_type>)
         {
             if (std::is_constant_evaluated())
                 return gcem::pow (src[i], exp);
@@ -169,7 +169,7 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
 #if VCTR_USE_GCEM
-        if constexpr (! is::complexNumber<value_type>)
+        if constexpr (! is::complexFloatNumber<value_type>)
         {
             if (std::is_constant_evaluated())
                 return gcem::pow (base, src[i]);

--- a/include/vctr/Expressions/ExpressionTemplate.h
+++ b/include/vctr/Expressions/ExpressionTemplate.h
@@ -144,7 +144,7 @@ void tryApplyingRuntimeArgsToThisExpression (const RuntimeArgs& args, Expression
 template <size_t i, class RuntimeArgs, is::anyVctrOrExpression Src>
 void tryApplyingRuntimeArgsToSrc (const RuntimeArgs& args, Src& src)
 {
-    if constexpr (has::iterateOverRuntimeArgChain<Src, i, RuntimeArgs>)
+    if constexpr (has::iterateOverRuntimeArgChain<Src, i, RuntimeArgs> && i < RuntimeArgs::size())
         src.template iterateOverRuntimeArgChain<i> (args);
 }
 

--- a/include/vctr/Expressions/ExpressionTemplate.h
+++ b/include/vctr/Expressions/ExpressionTemplate.h
@@ -45,7 +45,7 @@ struct ExpressionTemplateBase : Config
         {
             using Type = T;
 
-            static constexpr auto isFloatingPoint = is::floatNumber<Type>;
+            static constexpr auto isRealFloat = is::realFloatNumber<Type>;
 
             static constexpr auto isSigned = std::is_signed_v<Type>;
 
@@ -55,11 +55,7 @@ struct ExpressionTemplateBase : Config
 
             static constexpr auto isSignedInt = isSigned & isInt;
 
-            static constexpr auto isComplex = is::complexNumber<Type>;
-
-            static constexpr auto isComplexFloat = is::complexNumber<Type> && is::floatNumber<Type>;
-
-            static constexpr auto isComplexInt = is::complexNumber<Type> && ! is::floatNumber<Type>;
+            static constexpr auto isComplexFloat = is::complexFloatNumber<Type>;
 
             static constexpr auto isInt32 = std::same_as<int32_t, Type>;
 

--- a/include/vctr/Expressions/Filter/SIMDFilter.h
+++ b/include/vctr/Expressions/Filter/SIMDFilter.h
@@ -59,13 +59,13 @@ public:
 
     //==============================================================================
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && is::floatNumber<value_type>)
+    requires (archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>)
     {
         return src.getAVX (i);
     }
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx2") AVXRegister<value_type> getAVX (size_t i) const
-    requires (archX64 && has::getAVX<SrcType> && ! is::floatNumber<value_type>)
+    requires (archX64 && has::getAVX<SrcType> && ! is::realFloatNumber<value_type>)
     {
         return src.getAVX (i);
     }

--- a/include/vctr/Expressions/Generic/Map.h
+++ b/include/vctr/Expressions/Generic/Map.h
@@ -24,7 +24,7 @@ namespace vctr::expressions
 {
 
 template <size_t extent, class SrcType, is::rangeWithValueType<ValueType<SrcType>> RangeType>
-requires is::floatNumber<ValueType<SrcType>>
+requires is::realFloatNumber<ValueType<SrcType>>
 class Map : ExpressionTemplateBase
 {
 public:
@@ -78,7 +78,7 @@ private:
 };
 
 template <size_t extent, class SrcType, is::rangeWithValueType<ValueType<SrcType>> RangeType>
-requires is::floatNumber<ValueType<SrcType>>
+requires is::realFloatNumber<ValueType<SrcType>>
 class MapFrom0To1 : ExpressionTemplateBase
 {
 public:
@@ -128,7 +128,7 @@ private:
 };
 
 template <size_t extent, class SrcType, is::rangeWithValueType<ValueType<SrcType>> RangeType>
-requires is::floatNumber<ValueType<SrcType>>
+requires is::realFloatNumber<ValueType<SrcType>>
 class MapTo0To1 : ExpressionTemplateBase
 {
 public:
@@ -200,7 +200,7 @@ auto map (RangeType&& srcValueRange, RangeType&& dstValueRange)
 
     @ingroup Expressions
  */
-template <is::floatNumber T>
+template <is::realFloatNumber T>
 auto map (T srcValueRangeStart, T srcValueRangeEnd, T dstValueRangeStart, T dstValueRangeEnd)
 {
     return map (Range (srcValueRangeStart, srcValueRangeEnd), Range (dstValueRangeStart, dstValueRangeEnd));
@@ -224,7 +224,7 @@ auto mapFrom0To1 (RangeType&& dstValueRange)
 
     @ingroup Expressions
  */
-template <is::floatNumber T>
+template <is::realFloatNumber T>
 auto mapFrom0To1 (T dstValueRangeStart, T dstValueRangeEnd)
 {
     return mapFrom0To1 (vctr::Range (dstValueRangeStart, dstValueRangeEnd));
@@ -248,7 +248,7 @@ auto mapTo0To1 (RangeType&& srcValueRange)
 
     @ingroup Expressions
  */
-template <is::floatNumber T>
+template <is::realFloatNumber T>
 auto mapTo0To1 (T srcValueRangeStart, T srcValueRangeEnd)
 {
     return mapTo0To1 (Range (srcValueRangeStart, srcValueRangeEnd));

--- a/include/vctr/Expressions/Readme.md
+++ b/include/vctr/Expressions/Readme.md
@@ -196,7 +196,7 @@ add multiple implementations for different types, e.g. like this
 
 ```C++
 VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
-requires (archX64 && has::getSSE<SrcType> && is::floatNumber<SrcElementType>)
+requires (archX64 && has::getSSE<SrcType> && is::realFloatNumber<SrcElementType>)
 {
     static const auto sseSignBit = SSESrcType::broadcast (SrcElementType (-0.0));
 
@@ -230,7 +230,7 @@ handwritten SIMD code. We can also use them to execute our expressions. To do so
 
 ```C++
 VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
-requires (platformApple && has::evalNextVectorOpInExpressionChain<SrcType, value_type> && is::floatNumber<value_type>)
+requires (platformApple && has::evalNextVectorOpInExpressionChain<SrcType, value_type> && is::realFloatNumber<value_type>)
 {
     AccelerateRetType::abs (src.evalNextVectorOpInExpressionChain (dst), dst, int (size()));
     return dst;

--- a/include/vctr/Expressions/ReductionExpression.h
+++ b/include/vctr/Expressions/ReductionExpression.h
@@ -58,7 +58,7 @@ public:
 
         if constexpr (has::reduceAVXRegisterWise<Expression, ValueType<Expression>>)
         {
-            if constexpr (is::floatNumber<ValueType<Expression>>)
+            if constexpr (is::realFloatNumber<ValueType<Expression>>)
             {
                 if (Config::supportsAVX)
                     return reduceAVX (e);

--- a/include/vctr/PlatformVectorOps/Readme.md
+++ b/include/vctr/PlatformVectorOps/Readme.md
@@ -69,7 +69,7 @@ abs operation:
 
 ```C++
 const ReturnElementType* evalNextVectorOpInExpressionChain (ReturnElementType* dst) const
-requires (platformApple && has::evalNextVectorOpInExpressionChain<SrcType, ReturnElementType> && is::floatNumber<ReturnElementType>)
+requires (platformApple && has::evalNextVectorOpInExpressionChain<SrcType, ReturnElementType> && is::realFloatNumber<ReturnElementType>)
 {
     AccelerateRetType::abs (src.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
     return dst;
@@ -79,14 +79,14 @@ requires (platformApple && has::evalNextVectorOpInExpressionChain<SrcType, Retur
 We see that the first constraint is `platformApple` – this way, we would disable that function overload
 if we are building for a non-apple platform where the corresponding struct would be an empty dummy struct. Then, after
 checking if the source allows to evaluate vector ops, we check if the data type matches – Accelerate defines functions
-for `float` and `double` so we constrain it to `is::floatNumber`. This way, we can be sure that this code path is only
+for `float` and `double` so we constrain it to `is::realFloatNumber`. This way, we can be sure that this code path is only
 taken if we are evaluating abs for float or double on Apple.
 
 Now if this should also use IPP on x64 CPUs in case of non-apple, we could add another overload with different constraints like this:
 
 ```C++
 const ReturnElementType* evalNextVectorOpInExpressionChain (ReturnElementType* dst) const
-requires (hasIPP && ! platformApple && has::evalNextVectorOpInExpressionChain<SrcType, ReturnElementType> && is::floatNumber<ReturnElementType>)
+requires (hasIPP && ! platformApple && has::evalNextVectorOpInExpressionChain<SrcType, ReturnElementType> && is::realFloatNumber<ReturnElementType>)
 {
     IPPRetType::abs (src.evalNextVectorOpInExpressionChain (dst), dst, sizeToInt (size()));
     return dst;

--- a/include/vctr/TypeTraitsAndConcepts/ContainerAndExpressionConcepts.h
+++ b/include/vctr/TypeTraitsAndConcepts/ContainerAndExpressionConcepts.h
@@ -223,7 +223,7 @@ concept expressionWithEvalVectorOp = expression<T> && has::evalNextVectorOpInExp
 //==============================================================================
 /** A combined concept to check if Apple Accelerate is a suitable option for a real valued floating point vector operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::evalNextVectorOpInExpressionChain<Src, DstType> && floatNumber<DstType>;
+concept suitableForAccelerateRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::evalNextVectorOpInExpressionChain<Src, DstType> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a complex valued floating point vector operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
@@ -231,23 +231,23 @@ concept suitableForAccelerateComplexFloatVectorOp = detail::isPreferredVectorOp<
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a real or complex valued floating point vector operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateRealOrComplexFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::evalNextVectorOpInExpressionChain<Src, DstType> && (floatNumber<DstType> || complexFloatNumber<DstType>);
+concept suitableForAccelerateRealOrComplexFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::evalNextVectorOpInExpressionChain<Src, DstType> && (realFloatNumber<DstType> || complexFloatNumber<DstType>);
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a floating point vector operation that transforms a complex vector into a real one. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateComplexToRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && anyVctr<Src> && complexFloatNumber<typename std::remove_cvref_t<Src>::value_type> && floatNumber<DstType>;
+concept suitableForAccelerateComplexToRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && anyVctr<Src> && complexFloatNumber<typename std::remove_cvref_t<Src>::value_type> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a vector operation that transforms an integer vector into a floating point one. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateRealIntToFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::evalNextVectorOpInExpressionChain<Src, typename std::remove_cvref_t<Src>::value_type> && floatNumber<DstType> && intNumber<typename std::remove_cvref_t<Src>::value_type>;
+concept suitableForAccelerateRealIntToFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::evalNextVectorOpInExpressionChain<Src, typename std::remove_cvref_t<Src>::value_type> && realFloatNumber<DstType> && intNumber<typename std::remove_cvref_t<Src>::value_type>;
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a floating point vector reduction operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateRealFloatVectorReductionOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::data<Src> && floatNumber<DstType>;
+concept suitableForAccelerateRealFloatVectorReductionOp = detail::isPreferredVectorOp<pref> && Config::platformApple && has::data<Src> && realFloatNumber<DstType>;
 //==============================================================================
 /** A combined concept to check if Intel IPP is a suitable option for a real valued floating point vector operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::evalNextVectorOpInExpressionChain<Src, DstType> && floatNumber<DstType>;
+concept suitableForIppRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::evalNextVectorOpInExpressionChain<Src, DstType> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Intel IPP is a suitable option for a real valued singed int32 vector operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
@@ -259,19 +259,19 @@ concept suitableForIppComplexFloatVectorOp = detail::isPreferredVectorOp<pref> &
 
 /** A combined concept to check if Intel IPP is a suitable option for a real or complex valued floating point vector operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppRealOrComplexFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::evalNextVectorOpInExpressionChain<Src, DstType> && (floatNumber<DstType> || complexFloatNumber<DstType>);
+concept suitableForIppRealOrComplexFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::evalNextVectorOpInExpressionChain<Src, DstType> && (realFloatNumber<DstType> || complexFloatNumber<DstType>);
 
 /** A combined concept to check if Intel IPP is a suitable option for a floating point vector operation that transforms a complex vector into a real one. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppComplexToRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && anyVctr<Src> && complexFloatNumber<typename std::remove_cvref_t<Src>::value_type> && floatNumber<DstType>;
+concept suitableForIppComplexToRealFloatVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && anyVctr<Src> && complexFloatNumber<typename std::remove_cvref_t<Src>::value_type> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Intel IPP is a suitable option for a floating point vector reduction operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppRealFloatVectorReductionOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::data<Src> && floatNumber<DstType>;
+concept suitableForIppRealFloatVectorReductionOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::data<Src> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Intel IPP is a suitable option for a real or complex floating point vector reduction operation. */
 template <class Src, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppRealOrComplexFloatVectorReductionOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::data<Src> && (floatNumber<DstType> || complexFloatNumber<DstType>);
+concept suitableForIppRealOrComplexFloatVectorReductionOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && has::data<Src> && (realFloatNumber<DstType> || complexFloatNumber<DstType>);
 
 //==============================================================================
 /** Constrains two source types to be suitable for a an aliasing-free binary vector operation using platform vector ops. */
@@ -284,7 +284,7 @@ concept suitableForBinaryVectorOp = ((expressionWithEvalVectorOp < SrcA, DstType
 //==============================================================================
 /** A combined concept to check if Apple Accelerate is a suitable option for a real valued floating point binary vector operation. */
 template <class SrcA, class SrcB, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateRealFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && floatNumber<DstType>;
+concept suitableForAccelerateRealFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a complex valued floating point binary vector operation. */
 template <class SrcA, class SrcB, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
@@ -292,12 +292,12 @@ concept suitableForAccelerateComplexFloatBinaryVectorOp = detail::isPreferredVec
 
 /** A combined concept to check if Apple Accelerate is a suitable option for a real or complex valued floating point binary vector operation. */
 template <class SrcA, class SrcB, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForAccelerateRealOrComplexComplexFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && (floatNumber<DstType> || complexFloatNumber<DstType>);
+concept suitableForAccelerateRealOrComplexComplexFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::platformApple && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && (realFloatNumber<DstType> || complexFloatNumber<DstType>);
 
 //==============================================================================
 /** A combined concept to check if Intel IPP is a suitable option for a real valued floating point binary vector operation. */
 template <class SrcA, class SrcB, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppRealFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && floatNumber<DstType>;
+concept suitableForIppRealFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && realFloatNumber<DstType>;
 
 /** A combined concept to check if Intel IPP is a suitable option for a complex valued floating point binary vector operation. */
 template <class SrcA, class SrcB, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
@@ -305,7 +305,7 @@ concept suitableForIppComplexFloatBinaryVectorOp = detail::isPreferredVectorOp<p
 
 /** A combined concept to check if Intel IPP is a suitable option for a real or complex valued floating point binary vector operation. */
 template <class SrcA, class SrcB, class DstType, detail::PlatformVectorOpPreference pref = detail::preferIfIppAndAccelerateAreAvailable>
-concept suitableForIppRealOrComplexComplexFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && (floatNumber<DstType> || complexFloatNumber<DstType>);
+concept suitableForIppRealOrComplexComplexFloatBinaryVectorOp = detail::isPreferredVectorOp<pref> && Config::hasIPP && suitableForBinaryVectorOp<SrcA, SrcB, DstType> && (realFloatNumber<DstType> || complexFloatNumber<DstType>);
 
 //==============================================================================
 /** Constrains a type to supply a data and size function, an index operator and define a trivially copyable value_type. */

--- a/include/vctr/TypeTraitsAndConcepts/NumericTypeConcepts.h
+++ b/include/vctr/TypeTraitsAndConcepts/NumericTypeConcepts.h
@@ -26,13 +26,13 @@ namespace vctr::detail
 template <class T>
 struct IsNumber : std::bool_constant<std::is_arithmetic_v<T>> {};
 
-template <class T>
-struct IsNumber<std::complex<T>> : std::bool_constant<std::is_arithmetic_v<T>> {};
+template <std::floating_point T>
+struct IsNumber<std::complex<T>> : std::true_type {};
 
 template <class T>
 struct IsComplex : std::false_type {};
 
-template <class T>
+template <std::floating_point T>
 struct IsComplex<std::complex<T>> : std::true_type {};
 // clang-format on
 } // namespace vctr::detail
@@ -43,10 +43,6 @@ namespace vctr::is
 /** Constrains a type to represent a real valued or std::complex number type */
 template <class T>
 concept number = detail::IsNumber<T>::value;
-
-/** Constrains a type to represent a real valued floating point number */
-template <class T>
-concept floatNumber = std::is_floating_point_v<std::remove_cvref_t<T>>;
 
 /** Constrains a type to represent a real valued integer number */
 template <class T>
@@ -60,7 +56,7 @@ concept int32Number = intNumber<T> && sizeof (T) == 4;
 template <class T>
 concept int64Number = intNumber<T> && sizeof (T) == 8;
 
-/** Constrains a type to represent a real valued signed number (e.g. floatNumber or signedIntNumber) */
+/** Constrains a type to represent a real valued signed number (e.g. realFloatNumber or signedIntNumber) */
 template <class T>
 concept signedNumber = std::is_signed_v<std::remove_cvref_t<T>>;
 
@@ -78,17 +74,17 @@ concept unsignedIntNumber = intNumber<T> && ! signedNumber<T>;
 template <class T>
 concept realNumber = std::is_arithmetic_v<T>;
 
-/** Constrains a type to represent a complex valued number (that means, any instance of std::complex) */
+/** Constrains a type to represent a real valued floating point number */
 template <class T>
-concept complexNumber = detail::IsComplex<std::remove_cvref_t<T>>::value;
+concept realFloatNumber = std::is_floating_point_v<std::remove_cvref_t<T>>;
 
 /** Constrains a type to represent a complex valued floating point number (e.g. std::complex<float> or std::complex<double>) */
 template <class T>
-concept complexFloatNumber = complexNumber<T> && floatNumber<typename T::value_type>;
+concept complexFloatNumber = detail::IsComplex<std::remove_cvref_t<T>>::value;
 
-/** Constrains a type to represent a complex valued integer number */
+/** Constrains a type to represent a real or complex valued floating point number */
 template <class T>
-concept complexIntNumber = complexNumber<T> && intNumber<typename T::value_type>;
+concept realOrComplexFloatNumber = realFloatNumber<T> || complexFloatNumber<T>;
 
 /** Constrains a type to be of the type DisabledConstant */
 template <class T>

--- a/test/TestCases/Expressions/Add.cpp
+++ b/test/TestCases/Expressions/Add.cpp
@@ -76,7 +76,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Addition in place", "[add]", (PlatformVectorOps, VC
             REQUIRE_THAT (mac2[i].real(), Catch::Matchers::WithinRel ((srcA[i] + srcB[i] * c).real(), eps));
             REQUIRE_THAT (mac2[i].imag(), Catch::Matchers::WithinRel ((srcA[i] + srcB[i] * c).imag(), eps));
         }
-        else if constexpr (vctr::is::floatNumber<ElementType>)
+        else if constexpr (vctr::is::realFloatNumber<ElementType>)
         {
             REQUIRE_THAT (mac1[i], Catch::Matchers::WithinRel (srcA[i] + srcB[i] * srcC[i], eps));
             REQUIRE_THAT (mac2[i], Catch::Matchers::WithinRel (srcA[i] + srcB[i] * c, eps));

--- a/test/TestCases/Expressions/Decibels.cpp
+++ b/test/TestCases/Expressions/Decibels.cpp
@@ -23,8 +23,8 @@
 #include <vctr_test_utils/vctr_test_common.h>
 
 // clang-format off
-template <vctr::is::floatNumber T> auto magToDbFS    (T x) { return std::max (std::log10 (x) * T (20), T (-100)); }
-template <vctr::is::floatNumber T> auto magToDbPower (T x) { return std::max (std::log10 (x) * T (10), T (-100)); }
+template <vctr::is::realFloatNumber T> auto magToDbFS    (T x) { return std::max (std::log10 (x) * T (20), T (-100)); }
+template <vctr::is::realFloatNumber T> auto magToDbPower (T x) { return std::max (std::log10 (x) * T (10), T (-100)); }
 // clang-format on
 
 TEMPLATE_PRODUCT_TEST_CASE ("Decibels", "[Decibels]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )

--- a/test/TestCases/Expressions/Mean.cpp
+++ b/test/TestCases/Expressions/Mean.cpp
@@ -44,7 +44,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Mean", "[mean]", (PlatformVectorOps, VCTR_NATIVE_SI
         REQUIRE_THAT (meanU.real(), Catch::Matchers::WithinRel (refU.real(), eps));
         REQUIRE_THAT (meanU.imag(), Catch::Matchers::WithinRel (refU.imag(), eps));
     }
-    else if constexpr (vctr::is::floatNumber<ElementType>)
+    else if constexpr (vctr::is::realFloatNumber<ElementType>)
     {
         REQUIRE_THAT (mean, Catch::Matchers::WithinRel (meanMemFn, eps));
         REQUIRE_THAT (mean, Catch::Matchers::WithinRel (ref, eps));
@@ -83,7 +83,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("MeanSquare", "[meanSquare]", (PlatformVectorOps, VC
         REQUIRE_THAT (meanSquareU.real(), Catch::Matchers::WithinRel (refU.real(), eps));
         REQUIRE_THAT (meanSquareU.imag(), Catch::Matchers::WithinRel (refU.imag(), eps));
     }
-    else if constexpr (vctr::is::floatNumber<ElementType>)
+    else if constexpr (vctr::is::realFloatNumber<ElementType>)
     {
         REQUIRE_THAT (meanSquare, Catch::Matchers::WithinRel (meanSquareMemFn, eps));
         REQUIRE_THAT (meanSquare, Catch::Matchers::WithinRel (ref, eps));
@@ -122,7 +122,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("RMS", "[rms]", (PlatformVectorOps, VCTR_NATIVE_SIMD
         REQUIRE_THAT (rmsU.real(), Catch::Matchers::WithinRel (refU.real(), eps));
         REQUIRE_THAT (rmsU.imag(), Catch::Matchers::WithinRel (refU.imag(), eps));
     }
-    else if constexpr (vctr::is::floatNumber<ElementType>)
+    else if constexpr (vctr::is::realFloatNumber<ElementType>)
     {
         REQUIRE_THAT (rms, Catch::Matchers::WithinRel (rmsMemFn, eps));
         REQUIRE_THAT (rms, Catch::Matchers::WithinRel (ref, eps));

--- a/test/TestCases/Expressions/SquareCube.cpp
+++ b/test/TestCases/Expressions/SquareCube.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-template <vctr::is::floatNumber T>
+template <vctr::is::realFloatNumber T>
 T sqrt (T x) { return std::sqrt (x); }
 
 template <vctr::is::complexFloatNumber T>

--- a/test/TestCases/Expressions/Sum.cpp
+++ b/test/TestCases/Expressions/Sum.cpp
@@ -44,7 +44,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sum", "[sum]", (PlatformVectorOps, VCTR_NATIVE_SIMD
         REQUIRE_THAT (sumU.real(), Catch::Matchers::WithinRel (refU.real(), eps));
         REQUIRE_THAT (sumU.imag(), Catch::Matchers::WithinRel (refU.imag(), eps));
     }
-    else if constexpr (vctr::is::floatNumber<ElementType>)
+    else if constexpr (vctr::is::realFloatNumber<ElementType>)
     {
         REQUIRE_THAT (sum, Catch::Matchers::WithinRel (sumMemFn, eps));
         REQUIRE_THAT (sum, Catch::Matchers::WithinRel (ref, eps));


### PR DESCRIPTION
Rationale: `std::complex` only supports floating point numbers, so having concepts for complex float, complex int and general complex numbers was wrong in the first place. With this change there is only a concept for complex float numbers. Furthermore, the floatNumber concept has been renamed to realFloatNumber and a realOrComplexFloatNumber concept has been added