### PR TITLE
Expressions: Quick fix for an error where runtime arguments were not applied when a decibel expression was prepended

### DIFF
--- a/include/vctr/Expressions/BasicMath/Multiply.h
+++ b/include/vctr/Expressions/BasicMath/Multiply.h
@@ -140,29 +140,19 @@ class MultiplyVecByConstant : ExpressionTemplateBase
 public:
     using value_type = ValueType<SrcType>;
 
-    using Expression = ExpressionTypes<value_type, SrcType>;
-
     static constexpr auto constant = value_type (ConstantType::value);
 
-    template <class Src>
-    constexpr MultiplyVecByConstant (Src&& b)
-        : src (std::forward<Src> (b)),
-          asSSE (Expression::SSESrc::broadcast (constant)),
-          asNeon (Expression::NeonSrc::broadcast (constant))
-    {}
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (MultiplyVecByConstant, src)
 
-    constexpr const auto& getStorageInfo() const { return src.getStorageInfo(); }
-
-    constexpr size_t size() const { return src.size(); }
+    void applyRuntimeArgs()
+    {
+        asSSE = Expression::SSESrc::broadcast (constant);
+        asNeon = Expression::NeonSrc::broadcast (constant);
+    }
 
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
         return constant * src[i];
-    }
-
-    constexpr bool isNotAliased (const void* other) const
-    {
-        return src.isNotAliased (other);
     }
 
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
@@ -208,10 +198,9 @@ public:
     }
 
 private:
-    SrcType src;
 
-    const typename Expression::SSESrc asSSE;
-    const typename Expression::NeonSrc asNeon;
+    typename Expression::SSESrc asSSE;
+    typename Expression::NeonSrc asNeon;
 };
 
 } // namespace vctr::expressions

--- a/include/vctr/Expressions/BasicMath/NormalizeSum.h
+++ b/include/vctr/Expressions/BasicMath/NormalizeSum.h
@@ -40,9 +40,9 @@ public:
     VCTR_FORCEDINLINE constexpr value_type operator[] (size_t i) const
     {
         VCTR_ASSERT (srcSum != value_type (0));
-        VCTR_START_IGNORE_WARNING_MSVC (4723); // potential divide by 0
+        VCTR_START_IGNORE_WARNING_MSVC (4723) // potential divide by 0
         return src[i] / srcSum;
-        VCTR_END_IGNORE_WARNING_MSVC (4723);
+        VCTR_END_IGNORE_WARNING_MSVC
     }
 
     //==============================================================================

--- a/include/vctr/Expressions/DSP/Decibels.h
+++ b/include/vctr/Expressions/DSP/Decibels.h
@@ -82,7 +82,7 @@ struct dBPower : Constant<10> {};
    @ingroup Expressions
  */
 template <is::constant DecibelConstant, auto minDb = -100>
-constexpr inline ExpressionChainBuilder<expressions::MagToDb, DecibelConstant, Constant<minDb>> magToDb;
+constexpr inline ExpressionChainBuilderWithRuntimeArgs<expressions::MagToDb, detail::RuntimeArgChain<std::tuple<>, std::tuple<>, std::tuple<>>, DecibelConstant, Constant<minDb>> magToDb;
 
 /** Converts the source decibel values into their magnitude representation.
 
@@ -94,6 +94,6 @@ constexpr inline ExpressionChainBuilder<expressions::MagToDb, DecibelConstant, C
    @ingroup Expressions
  */
 template <is::constant DecibelConstant>
-constexpr inline ExpressionChainBuilder<expressions::DBToMag, DecibelConstant> dbToMag;
+constexpr inline ExpressionChainBuilderWithRuntimeArgs<expressions::DBToMag, detail::RuntimeArgChain<std::tuple<>, std::tuple<>, std::tuple<>>, DecibelConstant> dbToMag;
 
 } // namespace vctr

--- a/include/vctr/Expressions/ExpressionChainBuilder.h
+++ b/include/vctr/Expressions/ExpressionChainBuilder.h
@@ -46,10 +46,16 @@ public:
 
     constexpr RuntimeArgChain()
     requires (sizeof... (ArgTuples) == 1)
-    : chain {{ std::tuple<>() }}
+        : chain {{ std::tuple<>() }}
     {}
 
-    static consteval size_t size() { return sizeof... (ArgTuples); }
+    // TODO: This is a workaround for https://github.com/sonible/VCTR/issues/111 and should be replaced by a generic solution
+    constexpr RuntimeArgChain()
+    requires (sizeof... (ArgTuples) == 3)
+        : chain {{ std::tuple<>() }, { std::tuple<>() }, { std::tuple<>() }}
+    {}
+
+    static constexpr size_t size() { return sizeof... (ArgTuples); }
 
     template <is::stdTuple... ArgTuplesToPrepend>
     constexpr RuntimeArgChain<ArgTuplesToPrepend..., ArgTuples...> prepend (RuntimeArgChain<ArgTuplesToPrepend...> chainToPrepend) const


### PR DESCRIPTION
Should be fixed with a generic long term solution https://github.com/sonible/VCTR/issues/111