### PR TITLE
Expressions: Add target attributes to SIMD evaluation preparation calls

### DIFF
--- a/include/vctr/Expressions/BasicMath/Add.h
+++ b/include/vctr/Expressions/BasicMath/Add.h
@@ -108,8 +108,15 @@ public:
 
     //==============================================================================
     // AVX Implementation
-    void prepareAVXEvaluation() const
-    requires has::prepareAVXEvaluation<SrcType>
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const
+    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat
+    {
+        src.prepareAVXEvaluation();
+        singleSIMD.avx = Expression::AVX::broadcast (single);
+    }
+
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
+    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isInt
     {
         src.prepareAVXEvaluation();
         singleSIMD.avx = Expression::AVX::broadcast (single);
@@ -128,7 +135,7 @@ public:
     }
 
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();

--- a/include/vctr/Expressions/BasicMath/Divide.h
+++ b/include/vctr/Expressions/BasicMath/Divide.h
@@ -94,7 +94,7 @@ public:
 
     //==============================================================================
     // AVX Implementation
-    void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
@@ -108,7 +108,7 @@ public:
     }
 
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();
@@ -156,7 +156,7 @@ public:
 
     //==============================================================================
     // AVX Implementation
-    void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
@@ -170,7 +170,7 @@ public:
     }
 
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();

--- a/include/vctr/Expressions/BasicMath/Multiply.h
+++ b/include/vctr/Expressions/BasicMath/Multiply.h
@@ -119,7 +119,7 @@ public:
 
     //==============================================================================
     // AVX Implementation
-    void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
@@ -133,7 +133,7 @@ public:
     }
 
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();
@@ -194,7 +194,7 @@ public:
 
     //==============================================================================
     // AVX Implementation
-    void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
@@ -208,7 +208,7 @@ public:
     }
 
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();

--- a/include/vctr/Expressions/BasicMath/Subtract.h
+++ b/include/vctr/Expressions/BasicMath/Subtract.h
@@ -115,7 +115,7 @@ public:
 
     //==============================================================================
     // AVX Implementation
-    void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
@@ -135,7 +135,7 @@ public:
     }
 
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();
@@ -196,14 +196,14 @@ public:
     }
 
     //==============================================================================
-    void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();

--- a/include/vctr/Expressions/ExpressionTemplate.h
+++ b/include/vctr/Expressions/ExpressionTemplate.h
@@ -283,45 +283,58 @@ public:                                                                         
     constexpr bool isNotAliased (const void* other) const { return srcVecName.isNotAliased (other); }
 
 /** Forwards prepareNeonEvaluation(), prepareAVXEvaluation() and prepareSSEEvaluation() if the SrcType supplies them. */
-#define VCTR_FORWARD_PREPARE_SIMD_EVALUATION_UNARY_EXPRESSION_MEMBER_FUNCTIONS \
-    void prepareNeonEvaluation() const                                         \
-    requires has::prepareNeonEvaluation<SrcType>                               \
-    {                                                                          \
-        src.prepareNeonEvaluation();                                           \
-    }                                                                          \
-                                                                               \
-    void prepareAVXEvaluation() const                                          \
-    requires has::prepareAVXEvaluation<SrcType>                                \
-    {                                                                          \
-        src.prepareAVXEvaluation();                                            \
-    }                                                                          \
-                                                                               \
-    void prepareSSEEvaluation() const                                          \
-    requires has::prepareSSEEvaluation<SrcType>                                \
-    {                                                                          \
-        src.prepareSSEEvaluation();                                            \
+#define VCTR_FORWARD_PREPARE_SIMD_EVALUATION_UNARY_EXPRESSION_MEMBER_FUNCTIONS            \
+    void prepareNeonEvaluation() const                                                    \
+    requires has::prepareNeonEvaluation<SrcType>                                          \
+    {                                                                                     \
+        src.prepareNeonEvaluation();                                                      \
+    }                                                                                     \
+                                                                                          \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const              \
+    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat \
+    {                                                                                     \
+        src.prepareAVXEvaluation();                                                       \
+    }                                                                                     \
+                                                                                          \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx2") void prepareAVXEvaluation() const             \
+    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isInt       \
+    {                                                                                     \
+        src.prepareAVXEvaluation();                                                       \
+    }                                                                                     \
+                                                                                          \
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const            \
+    requires has::prepareSSEEvaluation<SrcType>                                           \
+    {                                                                                     \
+        src.prepareSSEEvaluation();                                                       \
     }
 
 /** Forwards prepareNeonEvaluation(), prepareAVXEvaluation() and prepareSSEEvaluation() if both source types supply them. */
-#define VCTR_FORWARD_PREPARE_SIMD_EVALUATION_BINARY_EXPRESSION_MEMBER_FUNCTIONS(srcAName, srcBName) \
-    void prepareNeonEvaluation() const                                                              \
-    requires has::prepareNeonEvaluation<SrcAType> && has::prepareNeonEvaluation<SrcBType>           \
-    {                                                                                               \
-        srcAName.prepareNeonEvaluation();                                                           \
-        srcBName.prepareNeonEvaluation();                                                           \
-    }                                                                                               \
-                                                                                                    \
-    void prepareAVXEvaluation() const                                                               \
-    requires has::prepareAVXEvaluation<SrcAType> && has::prepareAVXEvaluation<SrcBType>             \
-    {                                                                                               \
-        srcAName.prepareAVXEvaluation();                                                            \
-        srcBName.prepareAVXEvaluation();                                                            \
-    }                                                                                               \
-                                                                                                    \
-    void prepareSSEEvaluation() const                                                               \
-    requires has::prepareSSEEvaluation<SrcAType> && has::prepareSSEEvaluation<SrcBType>             \
-    {                                                                                               \
-        srcAName.prepareSSEEvaluation();                                                            \
-        srcBName.prepareSSEEvaluation();                                                            \
+#define VCTR_FORWARD_PREPARE_SIMD_EVALUATION_BINARY_EXPRESSION_MEMBER_FUNCTIONS(srcAName, srcBName)                               \
+    void prepareNeonEvaluation() const                                                                                            \
+    requires has::prepareNeonEvaluation<SrcAType> && has::prepareNeonEvaluation<SrcBType>                                         \
+    {                                                                                                                             \
+        srcAName.prepareNeonEvaluation();                                                                                         \
+        srcBName.prepareNeonEvaluation();                                                                                         \
+    }                                                                                                                             \
+                                                                                                                                  \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const                                                      \
+    requires has::prepareAVXEvaluation<SrcAType> && has::prepareAVXEvaluation<SrcBType> && Expression::CommonElement::isRealFloat \
+    {                                                                                                                             \
+        srcAName.prepareAVXEvaluation();                                                                                          \
+        srcBName.prepareAVXEvaluation();                                                                                          \
+    }                                                                                                                             \
+                                                                                                                                  \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx2") void prepareAVXEvaluation() const                                                     \
+    requires has::prepareAVXEvaluation<SrcAType> && has::prepareAVXEvaluation<SrcBType> && Expression::CommonElement::isInt       \
+    {                                                                                                                             \
+        srcAName.prepareAVXEvaluation();                                                                                          \
+        srcBName.prepareAVXEvaluation();                                                                                          \
+    }                                                                                                                             \
+                                                                                                                                  \
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const                                                    \
+    requires has::prepareSSEEvaluation<SrcAType> && has::prepareSSEEvaluation<SrcBType>                                           \
+    {                                                                                                                             \
+        srcAName.prepareSSEEvaluation();                                                                                          \
+        srcBName.prepareSSEEvaluation();                                                                                          \
     }
 // clang-format on

--- a/include/vctr/Expressions/Readme.md
+++ b/include/vctr/Expressions/Readme.md
@@ -240,8 +240,15 @@ public:
     //...
     
     // AVX Implementation
-    void prepareAVXEvaluation() const
-    requires has::prepareAVXEvaluation<SrcType>
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
+    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat
+    {
+        src.prepareAVXEvaluation();
+        singleSIMD.avx = Expression::AVX::broadcast (single);
+    }
+    
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
+    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isInt
     {
         src.prepareAVXEvaluation();
         singleSIMD.avx = Expression::AVX::broadcast (single);
@@ -260,7 +267,7 @@ public:
     }
     
     // SSE Implementation
-    void prepareSSEEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
     requires has::prepareSSEEvaluation<SrcType>
     {
         src.prepareSSEEvaluation();


### PR DESCRIPTION
This fixes issues when building with GCC 12 where broadcast instructions were not executed as expected
