### PR TITLE
Array: Fixed error for deleted assignment operator element types. Make sure that Array ctor is only exectued for copy constructible element types.

### DIFF
--- a/include/vctr/Containers/Array.h
+++ b/include/vctr/Containers/Array.h
@@ -71,10 +71,13 @@ public:
      */
     constexpr Array()
     {
-        if (std::is_constant_evaluated())
+        if constexpr (std::copy_constructible <ElementType>)
         {
-            if constexpr (extent > 0)
-                Vctr::storage.fill (value_type());
+            if (std::is_constant_evaluated())
+            {
+                if constexpr (extent > 0)
+                    Vctr::storage.fill (value_type());
+            }
         }
     }
 


### PR DESCRIPTION
…e sure that Array ctor is only exectued for copy constructible element types.