### PR TITLE
Unit Tests: Fixed compile error in Divide test with newer Apple Clang

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -33,7 +33,7 @@ jobs:
         run: doxygen-1.9.6/bin/doxygen
 
       - name: Save Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Documentation
           path: doxygen

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -17,9 +17,9 @@ jobs:
           #  cxx: clang++-15
           #  ipp: no_ipp
 
-          - runner: ubuntu-22.04
-            cc: gcc-12
-            cxx: g++-12
+          - runner: ubuntu-24.04
+            cc: gcc-13
+            cxx: g++-13
             ipp: no_ipp
 
           # Linux clang 15 runners are temporarily disabled due to installation issues. See https://github.com/sonible/VCTR/issues/86
@@ -28,9 +28,9 @@ jobs:
           #  cxx: clang++-15
           #  ipp: ipp
 
-          - runner: ubuntu-22.04
-            cc: gcc-12
-            cxx: g++-12
+          - runner: ubuntu-24.04
+            cc: gcc-13
+            cxx: g++-13
             ipp: ipp
 
           - runner: windows-2022

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -79,62 +79,31 @@ jobs:
           #   cxx: g++
           #   ipp: no_ipp
 
-          - runner: macos-12
+          # macos-14 and upwards runners are ARM based, therefore no IPP needed here
+          - runner: macos-14
             cc: clang
             cxx: clang++
             ipp: no_ipp
 
-          - runner: macos-12
-            # Todo: Should actually be $(brew --prefix llvm@15) but actions fails to resolve that when used here
+          # macos-13 is x86_64
+          # Todo: macos-13 runners run into std::pmr related runtime linker problems when building with non-brew llvm
+          # Todo: Should actually be $(brew --prefix llvm@15) but actions fails to resolve that when used here
+          - runner: macos-13
             cc: /usr/local/opt/llvm@15/bin/clang
             cxx: /usr/local/opt/llvm@15/bin/clang++
             ipp: no_ipp
 
-          #   Not supported yet
-          # - runner: [self-hosted, macOS, X64]
-          #   cc: /usr/local/opt/gcc/bin/gcc-12
-          #   cxx: /usr/local/opt/gcc/bin/g++-12
-          #   ipp: no_ipp
-
-          - runner: macos-12
-            cc: clang
-            cxx: clang++
-            ipp: ipp
-
-          - runner: macos-12
+          - runner: macos-13
             cc: /usr/local/opt/llvm@15/bin/clang
             cxx: /usr/local/opt/llvm@15/bin/clang++
             ipp: ipp
-
-          #   Not supported yet
-          # - runner: [self-hosted, macOS, X64]
-          #   cc: /usr/local/opt/gcc/bin/gcc-12
-          #   cxx: /usr/local/opt/gcc/bin/g++-12
-          #   ipp: ipp
-
-          #   Supported, Github does not provide ARM-based runners yet
-          # - runner: [self-hosted, macOS, ARM64]
-          #   cc: clang
-          #   cxx: clang++
-          #   ipp: no_ipp
-
-          #   Supported, Github does not provide ARM-based runners yet
-          # - runner: [self-hosted, macOS, ARM64]
-          #   cc: /opt/homebrew/opt/llvm/bin/clang
-          #   cxx: /opt/homebrew/opt/llvm/bin/clang++
-          #   ipp: no_ipp
-
-          #   Not supported yet
-          # - runner: [self-hosted, macOS, ARM64]
-          #   cc: /opt/homebrew/opt/gcc/bin/gcc-12
-          #   cxx: /opt/homebrew/opt/gcc/bin/g++-12
-          #   ipp: no_ipp
 
       fail-fast: false
 
     runs-on: ${{ matrix.configs.runner }}
 
     steps:
+
       - name: Checkout sources
         uses: actions/checkout@v3
 

--- a/Readme.md
+++ b/Readme.md
@@ -222,7 +222,7 @@ public types you can `#include <vctr/vctr_forward_declarations.h>` as a lightwei
 VCTR is using cutting-edge C++ library features and needs a recent compiler to work properly.
 It is currently tested with the following compilers:
 - Clang 15+
-- GCC 12+ (Linux only)
+- GCC 13+ (Linux only)
 - Visual Studio 2022+
 - XCode 14+
 

--- a/test/TestCases/Expressions/Divide.cpp
+++ b/test/TestCases/Expressions/Divide.cpp
@@ -28,12 +28,11 @@
 #pragma warning(disable : 4146)
 #endif
 
-template <class T>
-T division (T a, T b) { return a / b; }
-
 TEMPLATE_PRODUCT_TEST_CASE ("Division", "[divide]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_NO_ZEROS (10)
+
+    auto division = [] (ElementType a, ElementType b) { return a / b; };
 
     const auto c = srcC[0];
 
@@ -51,6 +50,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Division", "[divide]", (PlatformVectorOps, VCTR_NAT
 TEMPLATE_PRODUCT_TEST_CASE ("Divide in place", "[divide]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_NO_ZEROS (10)
+
+    auto division = [] (ElementType a, ElementType b) { return a / b; };
 
     const auto c = srcC[0];
 

--- a/test/TestMain/CMakeLists.txt
+++ b/test/TestMain/CMakeLists.txt
@@ -20,4 +20,8 @@ endif()
 # ================================================================================
 add_executable (vctr_test EXCLUDE_FROM_ALL vctr_test.cpp)
 
+if (APPLE)
+    target_compile_definitions (vctr_test PUBLIC -DACCELERATE_NEW_LAPACK)
+endif()
+
 target_link_libraries (vctr_test PRIVATE vctr vctr_test_utils vctr_test_cases Catch2::Catch2 gcem::gcem)

--- a/test/TestMain/CMakeLists.txt
+++ b/test/TestMain/CMakeLists.txt
@@ -5,7 +5,7 @@ project (VCTR_TEST)
 # ================================================================================
 
 if (VCTR_USE_CONAN)
-        conan_cmake_configure (REQUIRES catch2/3.1.0 gcem/1.16.0 BUILD missing GENERATORS cmake_find_package)
+        conan_cmake_configure (REQUIRES catch2/3.7.0 gcem/1.16.0 BUILD missing GENERATORS cmake_find_package)
         conan_cmake_autodetect (settings)
         conan_cmake_install (PATH_OR_REFERENCE . BUILD missing SETTINGS ${settings})
         set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
I ran into a compile error here when attempting to build the unit tests with a recent Xcode version. Seems like the compiler attempted to instantiate the function template with some invalid types. The lambdas with explicit argument types fixed it.