### PR TITLE
Expressions: Added multiply-add and multiply-subtract operations

### DIFF
--- a/include/vctr/Containers/VctrBase.h
+++ b/include/vctr/Containers/VctrBase.h
@@ -1013,15 +1013,15 @@ protected:
             {
                 if constexpr (is::realFloatNumber<ElementType>)
                 {
-                    if (supportsAVX)
+                    if (supportedCPUInstructionSets.fma)
                     {
-                        assignExpressionTemplateAVX (e);
+                        assignExpressionTemplateFMA (e);
                         return;
                     }
                 }
                 else
                 {
-                    if (supportsAVX2)
+                    if (supportedCPUInstructionSets.avx2)
                     {
                         assignExpressionTemplateAVX2 (e);
                         return;
@@ -1031,7 +1031,7 @@ protected:
 
             if constexpr (has::getSSE<Expression>)
             {
-                if (highestSupportedCPUInstructionSet != CPUInstructionSet::fallback)
+                if (supportedCPUInstructionSets.sse4_1)
                 {
                     assignExpressionTemplateSSE4_1 (e);
                     return;
@@ -1112,8 +1112,8 @@ private:
     }
 
     template <class Expression>
-    VCTR_TARGET ("avx")
-    void assignExpressionTemplateAVX (const Expression& e)
+    VCTR_TARGET ("fma")
+    void assignExpressionTemplateFMA (const Expression& e)
     requires archX64
     {
         constexpr auto inc = AVXRegister<ElementType>::numElements;

--- a/include/vctr/Expressions/BasicMath/Abs.h
+++ b/include/vctr/Expressions/BasicMath/Abs.h
@@ -80,7 +80,7 @@ public:
     }
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::CommonElement::isRealFloat)
     {
         static const auto avxSignBit = Expression::AVX::broadcast (typename Expression::CommonElement::Type (-0.0));

--- a/include/vctr/Expressions/BasicMath/Add.h
+++ b/include/vctr/Expressions/BasicMath/Add.h
@@ -59,7 +59,7 @@ public:
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_BINARY_EXPRESSION_MEMBER_FUNCTIONS (srcA, srcB)
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::add (srcA.getAVX (i), srcB.getAVX (i));
@@ -120,20 +120,13 @@ public:
     //==============================================================================
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
-    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat
+    requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
-    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isInt
-    {
-        src.prepareAVXEvaluation();
-        singleSIMD.avx = Expression::AVX::broadcast (single);
-    }
-
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::add (singleSIMD.avx, src.getAVX (i));
@@ -203,7 +196,7 @@ public:
         constantSIMD.avx = Expression::AVX::broadcast (constant);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::add (constantSIMD.avx, src.getAVX (i));

--- a/include/vctr/Expressions/BasicMath/Cube.h
+++ b/include/vctr/Expressions/BasicMath/Cube.h
@@ -41,7 +41,7 @@ public:
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_UNARY_EXPRESSION_MEMBER_FUNCTIONS
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires archX64 && has::getAVX<SrcType> && Expression::CommonElement::isRealFloat
     {
         auto x = src.getAVX (i);

--- a/include/vctr/Expressions/BasicMath/Divide.h
+++ b/include/vctr/Expressions/BasicMath/Divide.h
@@ -59,7 +59,7 @@ public:
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_BINARY_EXPRESSION_MEMBER_FUNCTIONS (srcA, srcB)
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::div (srcA.getAVX (i), srcB.getAVX (i));
@@ -104,7 +104,7 @@ public:
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::div (singleSIMD.avx, src.getAVX (i));
@@ -166,7 +166,7 @@ public:
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::div (src.getAVX (i), singleSIMD.avx);

--- a/include/vctr/Expressions/BasicMath/Max.h
+++ b/include/vctr/Expressions/BasicMath/Max.h
@@ -61,7 +61,7 @@ public:
         result = Expression::Neon::max (result, src.getNeon (i));
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::max (result, src.getAVX (i));
@@ -135,7 +135,7 @@ public:
         result = Expression::Neon::max (result, src.getNeon (i));
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         static const auto avxSignBit = Expression::AVX::broadcast (typename Expression::CommonElement::Type (-0.0));

--- a/include/vctr/Expressions/BasicMath/Mean.h
+++ b/include/vctr/Expressions/BasicMath/Mean.h
@@ -61,7 +61,7 @@ public:
         result = Expression::Neon::add (result, src.getNeon (i));
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::add (result, src.getAVX (i));
@@ -131,7 +131,7 @@ public:
         result = Expression::Neon::add (result, s);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         auto s = src.getAVX (i);
@@ -199,7 +199,7 @@ public:
         result = Expression::Neon::add (result, s);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         auto s = src.getAVX (i);

--- a/include/vctr/Expressions/BasicMath/Min.h
+++ b/include/vctr/Expressions/BasicMath/Min.h
@@ -61,7 +61,7 @@ public:
         result = Expression::Neon::min (result, src.getNeon (i));
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::min (result, src.getAVX (i));
@@ -135,7 +135,7 @@ public:
         result = Expression::Neon::min (result, src.getNeon (i));
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         static const auto avxSignBit = Expression::AVX::broadcast (typename Expression::CommonElement::Type (-0.0));

--- a/include/vctr/Expressions/BasicMath/Multiply.h
+++ b/include/vctr/Expressions/BasicMath/Multiply.h
@@ -72,7 +72,7 @@ public:
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_BINARY_EXPRESSION_MEMBER_FUNCTIONS (srcA, srcB)
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::mul (srcA.getAVX (i), srcB.getAVX (i));
@@ -137,7 +137,7 @@ public:
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::mul (singleSIMD.avx, src.getAVX (i));
@@ -212,7 +212,7 @@ public:
         constantSIMD.avx = Expression::AVX::broadcast (constant);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::mul (constantSIMD.avx, src.getAVX (i));

--- a/include/vctr/Expressions/BasicMath/MultiplyAccumulate.h
+++ b/include/vctr/Expressions/BasicMath/MultiplyAccumulate.h
@@ -1,0 +1,144 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2022- by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr::expressions
+{
+
+//==============================================================================
+/** Multiply-Accumulates three vector like types. */
+template <size_t extent, class SrcAType, class SrcBType, class SrcCType>
+requires are::same<ValueType<SrcAType>, ValueType<SrcBType>, ValueType<SrcCType>>
+class MultiplyAccumulateVectors : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcAType>;
+
+private:
+    using Expression = ExpressionTypes<value_type, SrcAType, SrcBType, SrcCType>;
+
+    using SrcAStorageInfoType = std::invoke_result_t<decltype (&std::remove_cvref_t<SrcAType>::getStorageInfo), SrcAType>;
+    using SrcBStorageInfoType = std::invoke_result_t<decltype (&std::remove_cvref_t<SrcBType>::getStorageInfo), SrcBType>;
+    using SrcCStorageInfoType = std::invoke_result_t<decltype (&std::remove_cvref_t<SrcCType>::getStorageInfo), SrcCType>;
+
+    SrcAType srcA;
+    SrcBType srcB;
+    SrcCType srcC;
+
+    const CombinedStorageInfo<std::remove_cvref_t<SrcAStorageInfoType>, std::remove_cvref_t<SrcBStorageInfoType>, std::remove_cvref_t<SrcCStorageInfoType>> storageInfo;
+
+public:
+    template <class SrcA, class SrcB, class SrcC>
+    constexpr MultiplyAccumulateVectors (SrcA&& a, SrcB&& b, SrcC&& c)
+        : srcA (std::forward<SrcA> (a)),
+          srcB (std::forward<SrcB> (b)),
+          srcC (std::forward<SrcC> (c)),
+          storageInfo (srcA.getStorageInfo(), srcB.getStorageInfo(), srcC.getStorageInfo())
+    {}
+
+    constexpr const auto& getStorageInfo() const { return storageInfo; }
+
+    constexpr size_t size() const { return srcA.size(); }
+
+    constexpr bool isNotAliased (const void*) const
+    {
+        return false;
+    }
+
+    VCTR_FORCEDINLINE constexpr auto operator[] (size_t i) const
+    {
+        return srcA[i] * srcB[i] + srcC[i];
+    }
+
+    //==============================================================================
+    void prepareNeonEvaluation() const
+    requires ::vctr::has::prepareNeonEvaluation<SrcAType> && ::vctr::has::prepareNeonEvaluation<SrcBType> && ::vctr::has::prepareNeonEvaluation<SrcCType>
+    {
+        srcA.prepareNeonEvaluation();
+        srcB.prepareNeonEvaluation();
+        srcC.prepareNeonEvaluation();
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx")
+    void prepareAVXEvaluation() const
+    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isRealFloat
+    {
+        srcA.prepareAVXEvaluation();
+        srcB.prepareAVXEvaluation();
+        srcC.prepareAVXEvaluation();
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
+    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isInt
+    {
+        srcA.prepareAVXEvaluation();
+        srcB.prepareAVXEvaluation();
+        srcC.prepareAVXEvaluation();
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
+    requires ::vctr::has::prepareSSEEvaluation<SrcAType> && ::vctr::has::prepareSSEEvaluation<SrcBType> && ::vctr::has::prepareSSEEvaluation<SrcCType>
+    {
+        srcA.prepareSSEEvaluation();
+        srcB.prepareSSEEvaluation();
+        srcC.prepareSSEEvaluation();
+    }
+
+    // AVX Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        return Expression::AVX::fma (srcA.getAVX (i), srcB.getAVX (i), srcC.getAVX (i));
+    }
+
+    //==============================================================================
+    // NEON Implementation
+    NeonRegister<value_type> getNeon (size_t i) const
+    requires (archARM && has::getNeon<SrcAType> && has::getNeon<SrcBType> && has::getNeon<SrcCType> && Expression::allElementTypesSame)
+    {
+        return Expression::Neon::fma (srcA.getNeon (i), srcB.getNeon (i), srcC.getNeon (i));
+    }
+};
+
+} // namespace vctr::expressions
+
+namespace vctr
+{
+
+/** Computes the multiply-accumulate operation (a * b) + c.
+
+    This is usually faster than evaluating these operations individually as it exploits
+    special hardware instructions. Prefer this for performance critical DSP implementations.
+
+    @ingroup Expressions
+ */
+template <class SrcAType, class SrcBType, class SrcCType>
+requires (is::anyVctrOrExpression<std::remove_cvref_t<SrcAType>> &&
+          is::anyVctrOrExpression<std::remove_cvref_t<SrcBType>> &&
+          is::anyVctrOrExpression<std::remove_cvref_t<SrcCType>>)
+constexpr auto multiplyAccumulate (SrcAType&& a, SrcBType&& b, SrcCType&& c)
+{
+    assertCommonSize (a, b, c);
+    constexpr auto extent = getCommonExtent<SrcAType, SrcBType, SrcCType>();
+
+    return expressions::MultiplyAccumulateVectors<extent, SrcAType, SrcBType, SrcCType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b), std::forward<SrcCType> (c));
+}
+} // namespace vctr

--- a/include/vctr/Expressions/BasicMath/MultiplyAccumulate.h
+++ b/include/vctr/Expressions/BasicMath/MultiplyAccumulate.h
@@ -77,17 +77,8 @@ public:
         srcC.prepareNeonEvaluation();
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx")
-    void prepareAVXEvaluation() const
-    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isRealFloat
-    {
-        srcA.prepareAVXEvaluation();
-        srcB.prepareAVXEvaluation();
-        srcC.prepareAVXEvaluation();
-    }
-
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
-    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isInt
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void prepareAVXEvaluation() const
+    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType>
     {
         srcA.prepareAVXEvaluation();
         srcB.prepareAVXEvaluation();
@@ -103,7 +94,7 @@ public:
     }
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::fma (srcA.getAVX (i), srcB.getAVX (i), srcC.getAVX (i));

--- a/include/vctr/Expressions/BasicMath/MultiplySubtract.h
+++ b/include/vctr/Expressions/BasicMath/MultiplySubtract.h
@@ -77,17 +77,8 @@ public:
         srcC.prepareNeonEvaluation();
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx")
-    void prepareAVXEvaluation() const
-    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isRealFloat
-    {
-        srcA.prepareAVXEvaluation();
-        srcB.prepareAVXEvaluation();
-        srcC.prepareAVXEvaluation();
-    }
-
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
-    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isInt
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void prepareAVXEvaluation() const
+    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType>
     {
         srcA.prepareAVXEvaluation();
         srcB.prepareAVXEvaluation();
@@ -103,7 +94,7 @@ public:
     }
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::fms (srcA.getAVX (i), srcB.getAVX (i), srcC.getAVX (i));

--- a/include/vctr/Expressions/BasicMath/MultiplySubtract.h
+++ b/include/vctr/Expressions/BasicMath/MultiplySubtract.h
@@ -1,0 +1,144 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2022- by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr::expressions
+{
+
+//==============================================================================
+/** Multiply-Accumulates three vector like types. */
+template <size_t extent, class SrcAType, class SrcBType, class SrcCType>
+requires are::same<ValueType<SrcAType>, ValueType<SrcBType>, ValueType<SrcCType>>
+class MultiplySubtractVectors : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcAType>;
+
+private:
+    using Expression = ExpressionTypes<value_type, SrcAType, SrcBType, SrcCType>;
+
+    using SrcAStorageInfoType = std::invoke_result_t<decltype (&std::remove_cvref_t<SrcAType>::getStorageInfo), SrcAType>;
+    using SrcBStorageInfoType = std::invoke_result_t<decltype (&std::remove_cvref_t<SrcBType>::getStorageInfo), SrcBType>;
+    using SrcCStorageInfoType = std::invoke_result_t<decltype (&std::remove_cvref_t<SrcCType>::getStorageInfo), SrcCType>;
+
+    SrcAType srcA;
+    SrcBType srcB;
+    SrcCType srcC;
+
+    const CombinedStorageInfo<std::remove_cvref_t<SrcAStorageInfoType>, std::remove_cvref_t<SrcBStorageInfoType>, std::remove_cvref_t<SrcCStorageInfoType>> storageInfo;
+
+public:
+    template <class SrcA, class SrcB, class SrcC>
+    constexpr MultiplySubtractVectors (SrcA&& a, SrcB&& b, SrcC&& c)
+        : srcA (std::forward<SrcA> (a)),
+          srcB (std::forward<SrcB> (b)),
+          srcC (std::forward<SrcC> (c)),
+          storageInfo (srcA.getStorageInfo(), srcB.getStorageInfo(), srcC.getStorageInfo())
+    {}
+
+    constexpr const auto& getStorageInfo() const { return storageInfo; }
+
+    constexpr size_t size() const { return srcA.size(); }
+
+    constexpr bool isNotAliased (const void*) const
+    {
+        return false;
+    }
+
+    VCTR_FORCEDINLINE constexpr auto operator[] (size_t i) const
+    {
+        return srcC[i] - srcA[i] * srcB[i];
+    }
+
+    //==============================================================================
+    void prepareNeonEvaluation() const
+    requires ::vctr::has::prepareNeonEvaluation<SrcAType> && ::vctr::has::prepareNeonEvaluation<SrcBType> && ::vctr::has::prepareNeonEvaluation<SrcCType>
+    {
+        srcA.prepareNeonEvaluation();
+        srcB.prepareNeonEvaluation();
+        srcC.prepareNeonEvaluation();
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx")
+    void prepareAVXEvaluation() const
+    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isRealFloat
+    {
+        srcA.prepareAVXEvaluation();
+        srcB.prepareAVXEvaluation();
+        srcC.prepareAVXEvaluation();
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
+    requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType> && Expression::CommonElement::isInt
+    {
+        srcA.prepareAVXEvaluation();
+        srcB.prepareAVXEvaluation();
+        srcC.prepareAVXEvaluation();
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
+    requires ::vctr::has::prepareSSEEvaluation<SrcAType> && ::vctr::has::prepareSSEEvaluation<SrcBType> && ::vctr::has::prepareSSEEvaluation<SrcCType>
+    {
+        srcA.prepareSSEEvaluation();
+        srcB.prepareSSEEvaluation();
+        srcC.prepareSSEEvaluation();
+    }
+
+    // AVX Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        return Expression::AVX::fms (srcA.getAVX (i), srcB.getAVX (i), srcC.getAVX (i));
+    }
+
+    //==============================================================================
+    // NEON Implementation
+    NeonRegister<value_type> getNeon (size_t i) const
+    requires (archARM && has::getNeon<SrcAType> && has::getNeon<SrcBType> && has::getNeon<SrcCType> && Expression::allElementTypesSame)
+    {
+        return Expression::Neon::fms (srcA.getNeon (i), srcB.getNeon (i), srcC.getNeon (i));
+    }
+};
+
+} // namespace vctr::expressions
+
+namespace vctr
+{
+
+/** Computes the multiply-subtract operation c - (a * b).
+
+    This is usually faster than evaluating these operations individually as it exploits
+    special hardware instructions. Prefer this for performance critical DSP implementations.
+
+    @ingroup Expressions
+ */
+template <class SrcAType, class SrcBType, class SrcCType>
+requires (is::anyVctrOrExpression<std::remove_cvref_t<SrcAType>> &&
+          is::anyVctrOrExpression<std::remove_cvref_t<SrcBType>> &&
+          is::anyVctrOrExpression<std::remove_cvref_t<SrcCType>>)
+constexpr auto multiplySubtract (SrcAType&& a, SrcBType&& b, SrcCType&& c)
+{
+    assertCommonSize (a, b, c);
+    constexpr auto extent = getCommonExtent<SrcAType, SrcBType, SrcCType>();
+
+    return expressions::MultiplySubtractVectors<extent, SrcAType, SrcBType, SrcCType> (std::forward<SrcAType> (a), std::forward<SrcBType> (b), std::forward<SrcCType> (c));
+}
+} // namespace vctr

--- a/include/vctr/Expressions/BasicMath/Square.h
+++ b/include/vctr/Expressions/BasicMath/Square.h
@@ -66,7 +66,7 @@ public:
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_UNARY_EXPRESSION_MEMBER_FUNCTIONS
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires archX64 && has::getAVX<SrcType> && Expression::CommonElement::isRealFloat
     {
         auto x = src.getAVX (i);

--- a/include/vctr/Expressions/BasicMath/Subtract.h
+++ b/include/vctr/Expressions/BasicMath/Subtract.h
@@ -59,7 +59,7 @@ public:
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_BINARY_EXPRESSION_MEMBER_FUNCTIONS (srcA, srcB)
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcAType> && has::getAVX<SrcBType> && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::sub (srcA.getAVX (i), srcB.getAVX (i));
@@ -125,7 +125,7 @@ public:
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::sub (singleSIMD.avx, src.getAVX (i));
@@ -221,7 +221,7 @@ public:
     }
 
     // AVX Implementation
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::sub (src.getAVX (i), singleSIMD.avx);

--- a/include/vctr/Expressions/BasicMath/Sum.h
+++ b/include/vctr/Expressions/BasicMath/Sum.h
@@ -77,7 +77,7 @@ public:
         result = Expression::Neon::add (result, src.getNeon (i));
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const
     requires Config::archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>
     {
         result = Expression::AVX::add (result, src.getAVX (i));

--- a/include/vctr/Expressions/DSP/FastExp.h
+++ b/include/vctr/Expressions/DSP/FastExp.h
@@ -54,7 +54,7 @@ public:
         SIMDConstMinus840.avx = Expression::AVX::broadcast (ConstMinus840);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         auto numerator = Expression::AVX::add (src.getAVX (i), SIMDConst20.avx);

--- a/include/vctr/Expressions/ExpressionTemplate.h
+++ b/include/vctr/Expressions/ExpressionTemplate.h
@@ -307,7 +307,7 @@ public:                                                                         
         src.prepareNeonEvaluation();                                                              \
     }                                                                                             \
                                                                                                   \
-    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const                      \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("fma") void prepareAVXEvaluation() const                      \
     requires ::vctr::has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat \
     {                                                                                             \
         src.prepareAVXEvaluation();                                                               \
@@ -334,7 +334,7 @@ public:                                                                         
         srcBName.prepareNeonEvaluation();                                                                                                         \
     }                                                                                                                                             \
                                                                                                                                                   \
-    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const                                                                      \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("fma") void prepareAVXEvaluation() const                                                                      \
     requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && Expression::CommonElement::isRealFloat \
     {                                                                                                                                             \
         srcAName.prepareAVXEvaluation();                                                                                                          \

--- a/include/vctr/Expressions/Filter/SIMDFilter.h
+++ b/include/vctr/Expressions/Filter/SIMDFilter.h
@@ -62,7 +62,7 @@ public:
     //==============================================================================
     VCTR_FORWARD_PREPARE_SIMD_EVALUATION_UNARY_EXPRESSION_MEMBER_FUNCTIONS
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>)
     {
         return src.getAVX (i);
@@ -120,7 +120,7 @@ public:
         return src.getSSE (i);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>)
     {
         return src.getAVX (i);
@@ -176,7 +176,7 @@ public:
         return src.getSSE (i);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && is::realFloatNumber<value_type>)
     {
         return src.getAVX (i);

--- a/include/vctr/Expressions/Readme.md
+++ b/include/vctr/Expressions/Readme.md
@@ -189,7 +189,7 @@ the expression:
 Intel architecture specific implementations have to be prefixed with the `VCTR_TARGET (<arch>)` macro to instruct
 the compiler to deliberately generate instructions for that instruction set, no matter what compiler flags are set. The
 calling side will do a runtime check if the corresponding functions are available at runtime. Valid values for `<arch>`
-are `"avx"`, `"avx2`" and `"sse4.1"`.
+are `"avx"`, `"fma"`, `"avx2"`" and `"sse4.1"`.
 
 In case implementations are only available or make sense for specific constraints, you can constrain them and possibly
 add multiple implementations for different types, e.g. like this
@@ -241,20 +241,13 @@ public:
     
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
-    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat
-    {
-        src.prepareAVXEvaluation();
-        singleSIMD.avx = Expression::AVX::broadcast (single);
-    }
-    
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void prepareAVXEvaluation() const
-    requires has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isInt
+    requires has::prepareAVXEvaluation<SrcType>
     {
         src.prepareAVXEvaluation();
         singleSIMD.avx = Expression::AVX::broadcast (single);
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") AVXRegister<value_type> getAVX (size_t i) const
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
         return Expression::AVX::add (singleSIMD.avx, src.getAVX (i));
@@ -403,7 +396,7 @@ When SIMD operations should be used, the required signature is
 ```c++
     VCTR_FORCEDINLINE void reduceNeonRegisterWise (NeonRegister<value_type>& result, size_t i) const;
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const;
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const;
 
     VCTR_FORCEDINLINE VCTR_TARGET ("avx2") void reduceAVXRegisterWise (AVXRegister<value_type>& result, size_t i) const;
 

--- a/include/vctr/Expressions/ReductionExpression.h
+++ b/include/vctr/Expressions/ReductionExpression.h
@@ -62,19 +62,19 @@ public:
             {
                 if constexpr (is::realFloatNumber<ValueType<Expression>>)
                 {
-                    if (Config::supportsAVX)
-                        return reduceAVX (e);
+                    if (Config::supportedCPUInstructionSets.fma)
+                        return reduceFMA (e);
                 }
                 else
                 {
-                    if (Config::supportsAVX2)
+                    if (Config::supportedCPUInstructionSets.avx2)
                         return reduceAVX2 (e);
                 }
             }
 
             if constexpr (has::reduceSSERegisterWise<Expression, ValueType<Expression>>)
             {
-                if (Config::highestSupportedCPUInstructionSet != CPUInstructionSet::fallback)
+                if (Config::supportedCPUInstructionSets.sse4_1)
                     return reduceSSE (e);
             }
         }
@@ -118,7 +118,7 @@ private:
     }
 
     template <is::reductionExpression Expression>
-    VCTR_TARGET ("avx") static auto reduceAVX (const Expression& e)
+    VCTR_TARGET ("fma") static auto reduceFMA (const Expression& e)
     requires Config::archX64
     {
         using VType = ValueType<Expression>;

--- a/include/vctr/Miscellaneous/Config.h
+++ b/include/vctr/Miscellaneous/Config.h
@@ -146,15 +146,19 @@
 namespace vctr
 {
 
-enum class CPUInstructionSet
+struct CPUInstructionSets
 {
-    sse4_1,
-    avx,
-    avx2,
+    uint16_t sse4_1 : 1;
 
-    neon,
+    uint16_t avx : 1;
 
-    fallback
+    // Note: CPUs that support AVX2 always support FMA and AVX
+    uint16_t avx2 : 1;
+
+    // Note: CPUs that support FMA always support AVX
+    uint16_t fma : 1;
+
+    uint16_t neon : 1;
 };
 
 #if VCTR_WINDOWS
@@ -237,43 +241,43 @@ private:
 };
 } // namespace detail
 
-inline CPUInstructionSet getHighestSupportedCPUInstructionSet()
+inline CPUInstructionSets getSupportedCPUInstructionSets()
 {
-    if (detail::X64InstructionSets::hasAVX2())
-        return CPUInstructionSet::avx2;
-
-    if (detail::X64InstructionSets::hasAVX())
-        return CPUInstructionSet::avx;
-
-    if (detail::X64InstructionSets::hasSSE41())
-        return CPUInstructionSet::sse4_1;
-
-    return CPUInstructionSet::fallback;
+    return {
+        .sse4_1 = detail::X64InstructionSets::hasSSE41(),
+        .avx = detail::X64InstructionSets::hasAVX(),
+        .avx2 = detail::X64InstructionSets::hasAVX2(),
+        .fma = detail::X64InstructionSets::hasFMA(),
+        .neon = false
+    };
 }
 
 #elif VCTR_ARM
 
-inline CPUInstructionSet getHighestSupportedCPUInstructionSet()
+constexpr CPUInstructionSets getSupportedCPUInstructionSets()
 {
-    return CPUInstructionSet::neon;
+    return {
+        .sse4_1 = false,
+        .avx = false,
+        .avx2 = false,
+        .fma = false,
+        .neon = true
+    };
 }
 
 #else
 
-inline CPUInstructionSet getHighestSupportedCPUInstructionSet()
+inline CPUInstructionSets getSupportedCPUInstructionSets()
 {
     __builtin_cpu_init();
 
-    if (__builtin_cpu_supports ("avx2"))
-        return CPUInstructionSet::avx2;
-
-    if (__builtin_cpu_supports ("avx"))
-        return CPUInstructionSet::avx;
-
-    if (__builtin_cpu_supports ("sse4.1"))
-        return CPUInstructionSet::sse4_1;
-
-    return CPUInstructionSet::fallback;
+    return {
+        .sse4_1 = __builtin_cpu_supports ("sse4.1"),
+        .avx = __builtin_cpu_supports ("avx"),
+        .avx2 = __builtin_cpu_supports ("avx2"),
+        .fma = __builtin_cpu_supports ("fma"),
+        .neon = false
+    };
 }
 
 #endif
@@ -292,11 +296,7 @@ consteval size_t trueCount()
 
 struct Config
 {
-    static const inline auto highestSupportedCPUInstructionSet = getHighestSupportedCPUInstructionSet();
-
-    static const inline auto supportsAVX2 = highestSupportedCPUInstructionSet == CPUInstructionSet::avx2;
-
-    static const inline auto supportsAVX = highestSupportedCPUInstructionSet == CPUInstructionSet::avx2 || highestSupportedCPUInstructionSet == CPUInstructionSet::avx;
+    static const inline auto supportedCPUInstructionSets = getSupportedCPUInstructionSets();
 
     //==============================================================================
     // Platform config

--- a/include/vctr/SIMD/AVX/AVXRegister.h
+++ b/include/vctr/SIMD/AVX/AVXRegister.h
@@ -64,6 +64,8 @@ struct AVXRegister<float>
     VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_ps (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_ps (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_ps (a.value, b.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_ps (a.value, b.value, c.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_ps (a.value, b.value, c.value) }; }
     // clang-format on
 };
 
@@ -80,7 +82,7 @@ struct AVXRegister<double>
     // clang-format off
     VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const double* d)                              { return { _mm256_loadu_pd (d) }; }
     VCTR_TARGET ("avx") static AVXRegister loadAligned   (const double* d)                              { return { _mm256_load_pd (d) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (double x) { return                            { _mm256_broadcast_sd (&x) }; }
+    VCTR_TARGET ("avx") static AVXRegister broadcast     (double x)                                     { return { _mm256_broadcast_sd (&x) }; }
     VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<double> a, SSERegister<double> b) { return { _mm256_set_m128d (a.value, b.value) }; }
 
     //==============================================================================
@@ -100,6 +102,8 @@ struct AVXRegister<double>
     VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_pd (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_pd (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_pd (a.value, b.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_pd (a.value, b.value, c.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_pd (a.value, b.value, c.value) }; }
     // clang-format on
 };
 

--- a/include/vctr/SIMD/AVX/AVXRegister.h
+++ b/include/vctr/SIMD/AVX/AVXRegister.h
@@ -64,8 +64,8 @@ struct AVXRegister<float>
     VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_ps (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_ps (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_ps (a.value, b.value, c.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_ps (a.value, b.value, c.value) }; }
+    VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_ps (a.value, b.value, c.value) }; }
+    VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_ps (a.value, b.value, c.value) }; }
     // clang-format on
 };
 
@@ -102,8 +102,8 @@ struct AVXRegister<double>
     VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_pd (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_pd (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_pd (a.value, b.value, c.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_pd (a.value, b.value, c.value) }; }
+    VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_pd (a.value, b.value, c.value) }; }
+    VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_pd (a.value, b.value, c.value) }; }
     // clang-format on
 };
 

--- a/include/vctr/SIMD/Neon/NeonRegister.h
+++ b/include/vctr/SIMD/Neon/NeonRegister.h
@@ -62,6 +62,8 @@ struct NeonRegister<float>
     static NeonRegister sub (NeonRegister a, NeonRegister b) { return { vsubq_f32 (a.value, b.value) }; }
     static NeonRegister max (NeonRegister a, NeonRegister b) { return { vmaxq_f32 (a.value, b.value) }; }
     static NeonRegister min (NeonRegister a, NeonRegister b) { return { vminq_f32 (a.value, b.value) }; }
+    static NeonRegister fma (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmaq_f32 (c.value, a.value, b.value) }; }
+    static NeonRegister fms (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmsq_f32 (c.value, a.value, b.value) }; }
     // clang-format on
 };
 
@@ -96,6 +98,8 @@ struct NeonRegister<double>
     static NeonRegister sub (NeonRegister a, NeonRegister b) { return { vsubq_f64 (a.value, b.value) }; }
     static NeonRegister max (NeonRegister a, NeonRegister b) { return { vmaxq_f64 (a.value, b.value) }; }
     static NeonRegister min (NeonRegister a, NeonRegister b) { return { vminq_f64 (a.value, b.value) }; }
+    static NeonRegister fma (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmaq_f64 (c.value, a.value, b.value) }; }
+    static NeonRegister fms (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmsq_f64 (c.value, a.value, b.value) }; }
     // clang-format on
 };
 

--- a/include/vctr/SIMD/SIMDHelpers.h
+++ b/include/vctr/SIMD/SIMDHelpers.h
@@ -193,12 +193,12 @@ template <class T>
 concept constexprStorageInfo = requires (const T&) { detail::ConstexprStorageInfoChecker<T::dataIsSIMDAligned, T::hasSIMDExtendedStorage>(); };
 }
 
-template <class InfoA, class InfoB>
+template <class First, class... Others>
 struct CombinedStorageInfo
 {
-    CombinedStorageInfo (const InfoA& a, const InfoB& b)
-        : dataIsSIMDAligned (a.dataIsSIMDAligned && b.dataIsSIMDAligned),
-          hasSIMDExtendedStorage (a.hasSIMDExtendedStorage && b.hasSIMDExtendedStorage)
+    CombinedStorageInfo (const First& first, const Others&... others)
+        : dataIsSIMDAligned (first.dataIsSIMDAligned && (others.dataIsSIMDAligned && ...)),
+          hasSIMDExtendedStorage (first.hasSIMDExtendedStorage && (others.hasSIMDExtendedStorage && ...))
     {}
 
     bool dataIsSIMDAligned;
@@ -206,14 +206,14 @@ struct CombinedStorageInfo
     bool hasSIMDExtendedStorage;
 };
 
-template <is::constexprStorageInfo InfoA, is::constexprStorageInfo InfoB>
-struct CombinedStorageInfo<InfoA, InfoB>
+template <is::constexprStorageInfo First, is::constexprStorageInfo... Others>
+struct CombinedStorageInfo<First, Others...>
 {
-    constexpr CombinedStorageInfo (const InfoA&, const InfoB&) {}
+    constexpr CombinedStorageInfo (const First&, const Others&...) {}
 
-    static constexpr bool dataIsSIMDAligned = InfoA::dataIsSIMDAligned && InfoB::dataIsSIMDAligned;
+    static constexpr bool dataIsSIMDAligned = First::dataIsSIMDAligned && (Others::dataIsSIMDAligned && ...);
 
-    static constexpr bool hasSIMDExtendedStorage = InfoA::hasSIMDExtendedStorage && InfoB::hasSIMDExtendedStorage;
+    static constexpr bool hasSIMDExtendedStorage = First::hasSIMDExtendedStorage && (Others::hasSIMDExtendedStorage && ...);
 };
 
 } // namespace vctr

--- a/include/vctr/TypeTraitsAndConcepts/Traits.h
+++ b/include/vctr/TypeTraitsAndConcepts/Traits.h
@@ -230,20 +230,23 @@ using StorageInfoType = typename detail::StorageInfoType<std::remove_cvref_t<T>>
 template <has::size T>
 constexpr size_t extentOf = detail::Extent<std::remove_cvref_t<T>>::value;
 
-/** Returns std::dynamic_extent in case both sources specify a dynamic extent.
-    Throws in case both sources specify a non-matching non-dynamic extent.
+/** Returns std::dynamic_extent in case all the sources specify a dynamic extent.
     Returns the non-dynamic extent found otherwise.
+
+    Note: This helper assumes, that you know that all sources have a common size.
+          If in doubt, use assertCommonSize to verify that.
  */
-template <class A, class B>
+template <class First, class... Other>
 consteval size_t getCommonExtent()
 {
-    if constexpr (extentOf<A> == std::dynamic_extent && extentOf<B> == std::dynamic_extent)
-        return std::dynamic_extent;
+    if constexpr (extentOf<First> == std::dynamic_extent) {
+        if constexpr (sizeof... (Other) == 0)
+            return std::dynamic_extent;
+        else
+            return getCommonExtent<Other...>();
+    }
 
-    if constexpr (extentOf<A> != std::dynamic_extent && extentOf<B> != std::dynamic_extent && extentOf<A> != extentOf<B>)
-        throw std::logic_error ("A and B both define different non-dynamic extents");
-
-    return extentOf<A> != std::dynamic_extent ? extentOf<A> : extentOf<B>;
+    return extentOf<First>;
 }
 
 /** Ensures that both sources have the same size. In case they both specify a non-dynamic extent,
@@ -259,6 +262,24 @@ constexpr void assertCommonSize ([[maybe_unused]] const A& a, [[maybe_unused]] c
     else
     {
         static_assert (extentOf<A> == extentOf<B>);
+    }
+}
+
+/** Ensures that all three sources have the same size. In case they all specify a non-dynamic extent,
+    this will be a compile-time static_assert, otherwise it will perform a runtime assert comparing the sizes.
+ */
+    template <class A, class B, class C>
+    constexpr void assertCommonSize ([[maybe_unused]] const A& a, [[maybe_unused]] const B& b, [[maybe_unused]] const C& c)
+{
+    if constexpr (extentOf<A> == std::dynamic_extent || extentOf<B> == std::dynamic_extent || extentOf<C> == std::dynamic_extent)
+    {
+        VCTR_ASSERT (a.size() == b.size());
+        VCTR_ASSERT (a.size() == c.size());
+    }
+    else
+    {
+        static_assert (extentOf<A> == extentOf<B>);
+        static_assert (extentOf<A> == extentOf<C>);
     }
 }
 

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -167,6 +167,8 @@ VCTR_END_IGNORE_WARNING_MSVC
 #include "Expressions/BasicMath/Add.h"
 #include "Expressions/BasicMath/Subtract.h"
 #include "Expressions/BasicMath/Multiply.h"
+#include "Expressions/BasicMath/MultiplyAccumulate.h"
+#include "Expressions/BasicMath/MultiplySubtract.h"
 #include "Expressions/BasicMath/Divide.h"
 #include "Expressions/BasicMath/Max.h"
 #include "Expressions/BasicMath/Min.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources (vctr_test_cases INTERFACE
         TestCases/Expressions/Max.cpp
         TestCases/Expressions/Mean.cpp
         TestCases/Expressions/Min.cpp
+        TestCases/Expressions/MultiplyAccumulate.cpp
         TestCases/Expressions/NormalizeSum.cpp
         TestCases/Expressions/Pow.cpp
         TestCases/Expressions/PowerSpectrum.cpp

--- a/test/TestCases/Expressions/MultiplyAccumulate.cpp
+++ b/test/TestCases/Expressions/MultiplyAccumulate.cpp
@@ -1,0 +1,49 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2022- by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+#include <vctr_test_utils/vctr_test_common.h>
+
+TEMPLATE_PRODUCT_TEST_CASE ("MultiplyAccumulate", "[VCTR][multiplyAccumulate]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+{
+    VCTR_TEST_DEFINES (10)
+
+    const vctr::Vector x = filter << vctr::multiplyAccumulate (srcA, srcB, srcC);
+
+    vctr::Array<ElementType, 10> xElementWise;
+    for (size_t i = 0; i < 10; ++i)
+        xElementWise[i] = (srcA[i] * srcB[i]) + srcC[i];
+
+    REQUIRE_THAT (x, vctr::Equals (xElementWise).withEpsilon (0.0001));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE ("MultiplySubtract", "[VCTR][multiplyAccumulate]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+{
+    VCTR_TEST_DEFINES (10)
+
+    const vctr::Vector x = filter << vctr::multiplySubtract (srcA, srcB, srcC);
+
+    vctr::Array<ElementType, 10> xElementWise;
+    for (size_t i = 0; i < 10; ++i)
+        xElementWise[i] = srcC[i] - (srcA[i] * srcB[i]);
+
+    REQUIRE_THAT (x, vctr::Equals (xElementWise).withEpsilon (0.0001));
+}


### PR DESCRIPTION
As this added the first ternary expressions yet, this needed a few adjustments to some helper functions. For the sake of getting stuff done I did not go the extra mile to also add macros to reduce the boilerplate code for those ternary expressions. Will do that in an upcoming change I guess