### PR TITLE
ExpressionTemplate: Fixed faulty fma target specifier in prepareAVXEvaluation functions

### DIFF
--- a/include/vctr/Expressions/BasicMath/MultiplyAccumulate.h
+++ b/include/vctr/Expressions/BasicMath/MultiplyAccumulate.h
@@ -77,7 +77,7 @@ public:
         srcC.prepareNeonEvaluation();
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType>
     {
         srcA.prepareAVXEvaluation();

--- a/include/vctr/Expressions/BasicMath/MultiplySubtract.h
+++ b/include/vctr/Expressions/BasicMath/MultiplySubtract.h
@@ -77,7 +77,7 @@ public:
         srcC.prepareNeonEvaluation();
     }
 
-    VCTR_FORCEDINLINE VCTR_TARGET ("fma") void prepareAVXEvaluation() const
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && ::vctr::has::prepareAVXEvaluation<SrcCType>
     {
         srcA.prepareAVXEvaluation();

--- a/include/vctr/Expressions/ExpressionTemplate.h
+++ b/include/vctr/Expressions/ExpressionTemplate.h
@@ -307,7 +307,7 @@ public:                                                                         
         src.prepareNeonEvaluation();                                                              \
     }                                                                                             \
                                                                                                   \
-    VCTR_FORCEDINLINE  VCTR_TARGET ("fma") void prepareAVXEvaluation() const                      \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const                      \
     requires ::vctr::has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat \
     {                                                                                             \
         src.prepareAVXEvaluation();                                                               \
@@ -334,7 +334,7 @@ public:                                                                         
         srcBName.prepareNeonEvaluation();                                                                                                         \
     }                                                                                                                                             \
                                                                                                                                                   \
-    VCTR_FORCEDINLINE  VCTR_TARGET ("fma") void prepareAVXEvaluation() const                                                                      \
+    VCTR_FORCEDINLINE  VCTR_TARGET ("avx") void prepareAVXEvaluation() const                                                                      \
     requires ::vctr::has::prepareAVXEvaluation<SrcAType> && ::vctr::has::prepareAVXEvaluation<SrcBType> && Expression::CommonElement::isRealFloat \
     {                                                                                                                                             \
         srcAName.prepareAVXEvaluation();                                                                                                          \


### PR DESCRIPTION
This fixes a bug introduced with the last FMA related changes that blocked some existing code from compiling. I decided to not raise the target of the `prepareAVXEvaluation` expression member functions to fma as it's not necessary but accidentally applied the target to a few occurrences.