### PR TITLE
Vctr 152 implement fast db calculations

### DIFF
--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -30,6 +30,7 @@ int main (int argc, char** argv) { return Catch::Session().run (argc, argv); }
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <chrono>
+#include <vctr_test_utils/vctr_test_common.h>
 
 // ===============================================================
 TEST_CASE ("Decibels")
@@ -187,4 +188,30 @@ TEST_CASE ("Multiplication")
             return notAccelerated();
         };
     }
+}
+
+TEST_CASE ("Precise vs fast decibel benchmarks",  "[VCTR][Decibels]")
+{
+    auto srcMag16 = UnitTestValues<float>::array<16, 0, 0, 2> (false, true);
+    auto srcDb16 = UnitTestValues<float>::array<16, 0, -100, 10> (false, true);
+
+    BENCHMARK ("Precise magToDb")
+    {
+        return vctr::Array (vctr::magToDb<vctr::dBFS> << srcMag16);
+    };
+
+    BENCHMARK ("Fast magToDb")
+    {
+        return vctr::Array (vctr::fastMagToDb<vctr::dBFS> << srcMag16);
+    };
+
+    BENCHMARK ("Precise dbToMag")
+    {
+        return vctr::Array (vctr::dbToMag<vctr::dBFS> << srcDb16);
+    };
+
+    BENCHMARK ("Fast dbToMag")
+    {
+        return vctr::Array (vctr::fastDbToMag<vctr::dBFS> << srcDb16);
+    };
 }

--- a/include/vctr/Expressions/BasicMath/Clamp.h
+++ b/include/vctr/Expressions/BasicMath/Clamp.h
@@ -147,6 +147,90 @@ public:
     }
 
     //==============================================================================
+    // AVX Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
+    requires (has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareAVXEvaluation();
+
+        if constexpr (clampLow)
+            lowerBoundSIMD.avx = Expression::AVX::broadcast (lowerBound);
+
+        if constexpr (clampHigh)
+            upperBoundSIMD.avx = Expression::AVX::broadcast (upperBound);
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto x = src.getAVX (i);
+
+        if constexpr (clampLow)
+            x = Expression::AVX::max (lowerBoundSIMD.avx, x);
+
+        if constexpr (clampHigh)
+            x = Expression::AVX::min (x, upperBoundSIMD.avx);
+
+        return x;
+    }
+
+    //==============================================================================
+    // SSE Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
+    requires (has::prepareSSEEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareSSEEvaluation();
+
+        if constexpr (clampLow)
+            lowerBoundSIMD.sse = Expression::SSE::broadcast (lowerBound);
+
+        if constexpr (clampHigh)
+            upperBoundSIMD.sse = Expression::SSE::broadcast (upperBound);
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto x = src.getSSE (i);
+
+        if constexpr (clampLow)
+            x = Expression::SSE::max (lowerBoundSIMD.sse, x);
+
+        if constexpr (clampHigh)
+            x = Expression::SSE::min (x, upperBoundSIMD.sse);
+
+        return x;
+    }
+
+    //==============================================================================
+    // Neon Implementation
+    void prepareNeonEvaluation() const
+    requires (archARM && has::prepareNeonEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareNeonEvaluation();
+
+        if constexpr (clampLow)
+            lowerBoundSIMD.neon = Expression::Neon::broadcast (lowerBound);
+
+        if constexpr (clampHigh)
+            upperBoundSIMD.neon = Expression::Neon::broadcast (upperBound);
+    }
+
+    NeonRegister<value_type> getNeon (size_t i) const
+    requires (archARM && has::getNeon<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto x = src.getNeon (i);
+
+        if constexpr (clampLow)
+            x = Expression::Neon::max (lowerBoundSIMD.neon, x);
+
+        if constexpr (clampHigh)
+            x = Expression::Neon::min (x, upperBoundSIMD.neon);
+
+        return x;
+    }
+
+    //==============================================================================
     // Platform Vector Operation Implementation
     VCTR_FORCEDINLINE const value_type* evalNextVectorOpInExpressionChain (value_type* dst) const
     requires is::suitableForAccelerateRealFloatVectorOp<SrcType, value_type, detail::dontPreferIfIppAndAccelerateAreAvailable>
@@ -181,6 +265,10 @@ public:
 
         return dst;
     }
+
+private:
+    mutable SIMDRegisterUnion<Expression> upperBoundSIMD;
+    mutable SIMDRegisterUnion<Expression> lowerBoundSIMD;
 };
 
 } // namespace vctr::expressions

--- a/include/vctr/Expressions/BasicMath/Multiply.h
+++ b/include/vctr/Expressions/BasicMath/Multiply.h
@@ -204,6 +204,20 @@ public:
     }
 
     //==============================================================================
+    // NEON Implementation
+    VCTR_FORCEDINLINE void prepareNeonEvaluation() const
+    requires has::prepareNeonEvaluation<SrcType>
+    {
+        src.prepareNeonEvaluation();
+        constantSIMD.neon = Expression::Neon::broadcast (constant);
+    }
+
+    VCTR_FORCEDINLINE NeonRegister<value_type> getNeon (size_t i) const
+    requires (archARM && has::getNeon<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        return Expression::Neon::mul (constantSIMD.neon, src.getNeon (i));
+    }
+
     // AVX Implementation
     VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
     requires has::prepareAVXEvaluation<SrcType>

--- a/include/vctr/Expressions/DSP/Decibels.h
+++ b/include/vctr/Expressions/DSP/Decibels.h
@@ -28,6 +28,19 @@ struct InvertedConstant
     static constexpr double value = 1.0 / double (C::value);
 };
 
+#if VCTR_USE_GCEM
+template <is::constant C>
+struct Log10ToLog2Constant
+{
+    static constexpr double value = double (C::value) / gcem::log2 (10.0);
+};
+
+template <is::constant C>
+struct InvertedLog10ToLog2Constant
+{
+    static constexpr double value = gcem::log2 (10.0) / double (C::value);
+};
+#endif
 } // namespace vctr::detail
 
 namespace vctr::expressions
@@ -45,8 +58,24 @@ template <size_t extent, class SrcType, class DecibelConstant>
 using DBToMag = PowConstantBase<extent,
                                 MultiplyVecByConstant<extent,
                                                       SrcType,
-                                                      detail::InvertedConstant<DecibelConstant>>,
+                                                      ::vctr::detail::InvertedConstant<DecibelConstant>>,
                                 Constant<10>>;
+
+#if VCTR_USE_GCEM
+template <size_t extent, class SrcType, class DecibelConstant, class MinDb>
+using FastMagToDb = ClampByConstant<extent,
+                                    MultiplyVecByConstant<extent,
+                                                          FastLog2<extent, SrcType>,
+                                                          ::vctr::detail::Log10ToLog2Constant<DecibelConstant>>,
+                                    MinDb,
+                                    DisabledConstant>;
+
+template <size_t extent, class SrcType, class DecibelConstant>
+using FastDbToMag = FastExp2<extent,
+                             MultiplyVecByConstant<extent,
+                                                   SrcType,
+                                                   ::vctr::detail::InvertedLog10ToLog2Constant<DecibelConstant>>>;
+#endif
 
 } // namespace vctr::expressions
 
@@ -95,5 +124,37 @@ constexpr inline ExpressionChainBuilderWithRuntimeArgs<expressions::MagToDb, det
  */
 template <is::constant DecibelConstant>
 constexpr inline ExpressionChainBuilderWithRuntimeArgs<expressions::DBToMag, detail::RuntimeArgChain<std::tuple<>, std::tuple<>, std::tuple<>>, DecibelConstant> dbToMag;
+
+#if VCTR_USE_GCEM
+/** Converts the source magnitude into a decibel representation using fast approximations.
+
+    The calculation is max (constant * log2 (src * log2 (10)), minDb), with constant being either 20 for dBFS or
+    dBVoltage (the typical value when dealing with digital audio amplitudes) or 10 for dBPower. The log2 function
+    is evaluated using the fastLog2 expression implementation, leading to an approximately 7x faster calculation
+    compared to the usual magToDb expression at the expense of some numerical precision.
+
+   @tparam DecibelConstant: Either vctr::dBFS, vctr::dBVoltage or vctr::dBPower.
+   @tparam minDb: The lower threshold for the resulting dB value and thus the value for a magnitude of 0.
+
+   @ingroup Expressions
+ */
+template <is::constant DecibelConstant, auto minDb = -100>
+constexpr inline ExpressionChainBuilderWithRuntimeArgs<expressions::FastMagToDb, detail::RuntimeArgChain<std::tuple<>, std::tuple<>, std::tuple<>>, DecibelConstant, Constant<minDb>> fastMagToDb;
+
+/** Converts the source decibel values into their magnitude representation using fast approximations.
+
+    The calculation is pow (2, src * (log2 (10) / constant), with constant being either 20 for dBFS or dBVoltage
+    (the typical value when dealing with digital audio amplitudes) or 10 for dBPower. The evaluation of 2 raised
+    to the power of src * (log2 (10) / constant is evaluated using the fastExp2 expression implementation, leading to
+    an approximately 5x faster calculation compared to the usual dbToMag expression at the expense of some numerical
+    precision.
+
+   @tparam DecibelConstant: Either vctr::dBFS, vctr::dBVoltage or vctr::dBPower.
+
+   @ingroup Expressions
+ */
+template <is::constant DecibelConstant>
+constexpr inline ExpressionChainBuilderWithRuntimeArgs<expressions::FastDbToMag, detail::RuntimeArgChain<std::tuple<>, std::tuple<>, std::tuple<>>, DecibelConstant> fastDbToMag;
+#endif
 
 } // namespace vctr

--- a/include/vctr/Expressions/DSP/FastExp.h
+++ b/include/vctr/Expressions/DSP/FastExp.h
@@ -172,6 +172,202 @@ private:
     mutable SIMDRegisterUnion<Expression> SIMDConstMinus840 {};
 };
 
+namespace detail
+{
+
+template <std::floating_point>
+struct FastExp2Constants {};
+
+template <>
+struct FastExp2Constants<float>
+{
+    static constexpr int mantissaBits = 23;
+    static constexpr float minExpo = -126.0f; // exponent of minimum binary32 normal
+    static constexpr float expoBias = 127.0f; // binary32 exponent bias
+    static constexpr float a = -0x1.6e7592p+2f;
+    static constexpr float b = 0x1.bba764p+4f;
+    static constexpr float c = 0x1.35ed00p+2f;
+    static constexpr float d = 0x1.f5e546p-2f;
+    static constexpr float e = 1 << mantissaBits;
+};
+
+template <>
+struct FastExp2Constants<double>
+{
+    static constexpr int mantissaBits = 52;
+    static constexpr double minExpo = -1022.0; // exponent of minimum binary64 normal
+    static constexpr double expoBias = 1023.0; // binary64 exponent bias
+    static constexpr double a = -0x1.6e75d58p+2;
+    static constexpr double b = 0x1.bba7414p+4;
+    static constexpr double c = 0x1.35eccbap+2;
+    static constexpr double d = 0x1.f5e53c2p-2;
+    static constexpr double e = 1LL << mantissaBits;
+};
+}
+
+//==============================================================================
+/** Calculates a fast approximation for the exp2 function.
+
+    This implementation is inspired by https://stackoverflow.com/a/65562273. It relies
+    on reinterpreting the bytes of a float as integer and manipulating the exponent and
+    mantissa part.
+ */
+template <size_t extent, class SrcType>
+requires is::realFloatNumber<ValueType<SrcType>>
+class FastExp2 : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcType>;
+
+    using Constants = detail::FastExp2Constants<value_type>;
+
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (FastExp2, src)
+
+    VCTR_FORCEDINLINE value_type operator[] (size_t i) const
+    {
+        auto p = src[i];
+
+        p = std::max (p, Constants::minExpo);
+
+        auto w = std::floor (p);
+        auto z = p - w;
+
+        auto approx = Constants::a + Constants::b / (Constants::c - z) - Constants::d * z;
+
+        auto resi = IntType (Constants::e * (w + Constants::expoBias + approx));
+
+
+        return bitCast<value_type> (resi);
+    }
+
+    //==============================================================================
+    // AVX Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
+    requires (has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isFloat)
+    {
+        src.prepareAVXEvaluation();
+
+        minExpo.avx = Expression::AVX::broadcast (Constants::minExpo);
+        expoBias.avx = Expression::AVX::broadcast (Constants::expoBias);
+        c_a.avx = Expression::AVX::broadcast (Constants::a);
+        c_b.avx = Expression::AVX::broadcast (Constants::b);
+        c_c.avx = Expression::AVX::broadcast (Constants::c);
+        c_d.avx = Expression::AVX::broadcast (Constants::d);
+        c_e.avx = Expression::AVX::broadcast (Constants::e);
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloat)
+    {
+        auto in = src.getAVX (i);
+
+        in = Expression::AVX::max (in, minExpo.avx);
+
+        auto w = Expression::AVX::floor (in);
+        auto z = Expression::AVX::sub (in, w);
+
+        auto approx = Expression::AVX::sub (Expression::AVX::add (c_a.avx ,
+                                                                  Expression::AVX::div (c_b.avx,
+                                                                                        Expression::AVX::sub (c_c.avx, z))),
+                                            Expression::AVX::mul (c_d.avx,
+                                                                  z)
+                                             );
+
+        auto resi = Expression::AVX::mul (c_e.avx, Expression::AVX::add (w, Expression::AVX::add (expoBias.avx, approx)));
+
+        // ConvertToInt requires AVX512 features for double registers, so this implementation is constrained to float
+        return AVXRegister<IntType>::reinterpretAsFp (Expression::AVX::convertToInt (resi));
+    }
+
+    //==============================================================================
+    // SSE Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
+    requires (has::prepareSSEEvaluation<SrcType> && Expression::CommonElement::isFloat)
+    {
+        src.prepareSSEEvaluation();
+
+        minExpo.sse = Expression::SSE::broadcast (Constants::minExpo);
+        expoBias.sse = Expression::SSE::broadcast (Constants::expoBias);
+        c_a.sse = Expression::SSE::broadcast (Constants::a);
+        c_b.sse = Expression::SSE::broadcast (Constants::b);
+        c_c.sse = Expression::SSE::broadcast (Constants::c);
+        c_d.sse = Expression::SSE::broadcast (Constants::d);
+        c_e.sse = Expression::SSE::broadcast (Constants::e);
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isFloat)
+    {
+        auto in = src.getSSE (i);
+
+        in = Expression::SSE::max (in, minExpo.sse);
+
+        auto w = Expression::SSE::floor (in);
+        auto z = Expression::SSE::sub (in, w);
+
+        auto approx = Expression::SSE::sub (Expression::SSE::add (c_a.sse ,
+                                                                  Expression::SSE::div (c_b.sse,
+                                                                                        Expression::SSE::sub (c_c.sse, z))),
+                                            Expression::SSE::mul (c_d.sse,
+                                                                  z)
+                                             );
+
+        auto resi = Expression::SSE::mul (c_e.sse, Expression::SSE::add (w, Expression::SSE::add (expoBias.sse, approx)));
+
+        // ConvertToInt requires AVX512 features for double registers, so this implementation is constrained to float
+        return SSERegister<IntType>::reinterpretAsFp (Expression::SSE::convertToInt (resi));
+    }
+
+    //==============================================================================
+    // Neon Implementation
+    void prepareNeonEvaluation() const
+    requires (archARM && has::prepareNeonEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareNeonEvaluation();
+
+        minExpo.neon = Expression::Neon::broadcast (Constants::minExpo);
+        expoBias.neon = Expression::Neon::broadcast (Constants::expoBias);
+        c_a.neon = Expression::Neon::broadcast (Constants::a);
+        c_b.neon = Expression::Neon::broadcast (Constants::b);
+        c_c.neon = Expression::Neon::broadcast (Constants::c);
+        c_d.neon = Expression::Neon::broadcast (Constants::d);
+        c_e.neon = Expression::Neon::broadcast (Constants::e);
+    }
+
+    NeonRegister<value_type> getNeon (size_t i) const
+    requires (archARM && has::getNeon<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto in = src.getNeon (i);
+
+        in = Expression::Neon::max (in, minExpo.neon);
+
+        auto w = Expression::Neon::floor (in);
+        auto z = Expression::Neon::sub (in, w);
+
+        auto approx = Expression::Neon::sub (Expression::Neon::add (c_a.neon ,
+                                                                    Expression::Neon::div (c_b.neon,
+                                                                                           Expression::Neon::sub (c_c.neon, z))),
+                                             Expression::Neon::mul (c_d.neon,
+                                                                    z)
+                                             );
+
+        auto resi = Expression::Neon::mul (c_e.neon, Expression::Neon::add (w, Expression::Neon::add (expoBias.neon, approx)));
+
+        return NeonRegister<IntType>::reinterpretAsFp (Expression::Neon::convertToInt (resi));
+    }
+
+private:
+    using IntType = std::conditional_t<std::same_as<float, value_type>, int32_t, int64_t>;
+
+    mutable SIMDRegisterUnion<Expression> minExpo;
+    mutable SIMDRegisterUnion<Expression> expoBias;
+    mutable SIMDRegisterUnion<Expression> c_e;
+    mutable SIMDRegisterUnion<Expression> c_a;
+    mutable SIMDRegisterUnion<Expression> c_b;
+    mutable SIMDRegisterUnion<Expression> c_c;
+    mutable SIMDRegisterUnion<Expression> c_d;
+};
+
 } // namespace vctr::expressions
 
 namespace vctr
@@ -184,5 +380,15 @@ namespace vctr
     @ingroup Expressions
  */
 constexpr inline ExpressionChainBuilder<expressions::FastExp> fastExp;
+
+/** A fast approximation of the exp2 function (e.g. 2 raised to the source elements) exploiting some low level details of the
+    binary representation of floating point values.
+
+    Limit the input values to -126 < x < 128 for 32 bit float and -1022.0 < x < 2024 for 64 bit double for a reasonable
+    approximation which should not exceed a relative error of 5.04e-5.
+
+    @ingroup Expressions
+ */
+constexpr inline ExpressionChainBuilder<expressions::FastExp2> fastExp2;
 
 } // namespace vctr

--- a/include/vctr/Expressions/DSP/FastExp.h
+++ b/include/vctr/Expressions/DSP/FastExp.h
@@ -57,20 +57,22 @@ public:
     VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
     requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
-        auto numerator = Expression::AVX::add (src.getAVX (i), SIMDConst20.avx);
-        numerator = Expression::AVX::mul (numerator, src.getAVX (i));
+        const auto in = src.getAVX (i);
+
+        auto numerator = Expression::AVX::add (in, SIMDConst20.avx);
+        numerator = Expression::AVX::mul (numerator, in);
         numerator = Expression::AVX::add (numerator, SIMDConst180.avx);
-        numerator = Expression::AVX::mul (numerator, src.getAVX (i));
+        numerator = Expression::AVX::mul (numerator, in);
         numerator = Expression::AVX::add (numerator, SIMDConst840.avx);
-        numerator = Expression::AVX::mul (numerator, src.getAVX (i));
+        numerator = Expression::AVX::mul (numerator, in);
         numerator = Expression::AVX::add (numerator, SIMDConst1680.avx);
 
-        auto denominator = Expression::AVX::add (src.getAVX (i), SIMDConstMinus20.avx);
-        denominator = Expression::AVX::mul (denominator, src.getAVX (i));
+        auto denominator = Expression::AVX::add (in, SIMDConstMinus20.avx);
+        denominator = Expression::AVX::mul (denominator, in);
         denominator = Expression::AVX::add (denominator, SIMDConst180.avx);
-        denominator = Expression::AVX::mul (denominator, src.getAVX (i));
+        denominator = Expression::AVX::mul (denominator, in);
         denominator = Expression::AVX::add (denominator, SIMDConstMinus840.avx);
-        denominator = Expression::AVX::mul (denominator, src.getAVX (i));
+        denominator = Expression::AVX::mul (denominator, in);
         denominator = Expression::AVX::add (denominator, SIMDConst1680.avx);
 
         return Expression::AVX::div (numerator, denominator);
@@ -94,20 +96,22 @@ public:
     VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
     requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
-        auto numerator = Expression::SSE::add (src.getSSE (i), SIMDConst20.sse);
-        numerator = Expression::SSE::mul (numerator, src.getSSE (i));
+        const auto in = src.getSSE (i);
+
+        auto numerator = Expression::SSE::add (in, SIMDConst20.sse);
+        numerator = Expression::SSE::mul (numerator, in);
         numerator = Expression::SSE::add (numerator, SIMDConst180.sse);
-        numerator = Expression::SSE::mul (numerator, src.getSSE (i));
+        numerator = Expression::SSE::mul (numerator, in);
         numerator = Expression::SSE::add (numerator, SIMDConst840.sse);
-        numerator = Expression::SSE::mul (numerator, src.getSSE (i));
+        numerator = Expression::SSE::mul (numerator, in);
         numerator = Expression::SSE::add (numerator, SIMDConst1680.sse);
 
-        auto denominator = Expression::SSE::add (src.getSSE (i), SIMDConstMinus20.sse);
-        denominator = Expression::SSE::mul (denominator, src.getSSE (i));
+        auto denominator = Expression::SSE::add (in, SIMDConstMinus20.sse);
+        denominator = Expression::SSE::mul (denominator, in);
         denominator = Expression::SSE::add (denominator, SIMDConst180.sse);
-        denominator = Expression::SSE::mul (denominator, src.getSSE (i));
+        denominator = Expression::SSE::mul (denominator, in);
         denominator = Expression::SSE::add (denominator, SIMDConstMinus840.sse);
-        denominator = Expression::SSE::mul (denominator, src.getSSE (i));
+        denominator = Expression::SSE::mul (denominator, in);
         denominator = Expression::SSE::add (denominator, SIMDConst1680.sse);
 
         return Expression::SSE::div (numerator, denominator);
@@ -131,20 +135,22 @@ public:
     NeonRegister<value_type> getNeon (size_t i) const
     requires (archARM && has::getNeon<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
     {
-        auto numerator = Expression::Neon::add (src.getNeon (i), SIMDConst20.neon);
-        numerator = Expression::Neon::mul (numerator, src.getNeon (i));
+        const auto in = src.getNeon (i);
+
+        auto numerator = Expression::Neon::add (in, SIMDConst20.neon);
+        numerator = Expression::Neon::mul (numerator, in);
         numerator = Expression::Neon::add (numerator, SIMDConst180.neon);
-        numerator = Expression::Neon::mul (numerator, src.getNeon (i));
+        numerator = Expression::Neon::mul (numerator, in);
         numerator = Expression::Neon::add (numerator, SIMDConst840.neon);
-        numerator = Expression::Neon::mul (numerator, src.getNeon (i));
+        numerator = Expression::Neon::mul (numerator, in);
         numerator = Expression::Neon::add (numerator, SIMDConst1680.neon);
 
-        auto denominator = Expression::Neon::add (src.getNeon (i), SIMDConstMinus20.neon);
-        denominator = Expression::Neon::mul (denominator, src.getNeon (i));
+        auto denominator = Expression::Neon::add (in, SIMDConstMinus20.neon);
+        denominator = Expression::Neon::mul (denominator, in);
         denominator = Expression::Neon::add (denominator, SIMDConst180.neon);
-        denominator = Expression::Neon::mul (denominator, src.getNeon (i));
+        denominator = Expression::Neon::mul (denominator, in);
         denominator = Expression::Neon::add (denominator, SIMDConstMinus840.neon);
-        denominator = Expression::Neon::mul (denominator, src.getNeon (i));
+        denominator = Expression::Neon::mul (denominator, in);
         denominator = Expression::Neon::add (denominator, SIMDConst1680.neon);
 
         return Expression::Neon::div (numerator, denominator);

--- a/include/vctr/Expressions/DSP/FastLog.h
+++ b/include/vctr/Expressions/DSP/FastLog.h
@@ -1,0 +1,215 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2025- by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr::expressions
+{
+
+namespace detail
+{
+
+template <std::floating_point T>
+struct FastLog2Constants {};
+
+template <>
+struct FastLog2Constants<float>
+{
+    static constexpr float a              { 1.1920928955078125e-7f };
+    static constexpr float b              { 124.22551499f };
+    static constexpr float c              { 1.498030302f };
+    static constexpr float d              { 1.72587999f };
+    static constexpr float e              { 0.3520887068f };
+    static constexpr int32_t c_0x007fffff { 0x007fffff }; // Masks the mantissa bits
+    static constexpr int32_t c_0x3f000000 { 0x3f000000 };
+    // clang-format on
+};
+}
+
+//==============================================================================
+/** Calculates a fast approximation for the log2 function.
+
+    This implementation is inspired by
+    https://github.com/romeric/fastapprox/blob/ccc534400ec3e0f67de4eafb53377334962d9db6/fastapprox/src/fastlog.h#L48.
+    It relies on reinterpreting the bytes of a float as integer and manipulating the
+    exponent and mantissa part.
+ */
+template <size_t extent, class SrcType>
+requires std::same_as<float, ValueType<SrcType>>
+class FastLog2 : ExpressionTemplateBase
+{
+public:
+    using value_type = ValueType<SrcType>;
+
+    using Constants = detail::FastLog2Constants<value_type>;
+
+    VCTR_COMMON_UNARY_EXPRESSION_MEMBERS (FastLog2, src)
+
+    VCTR_FORCEDINLINE value_type operator[] (size_t i) const
+    {
+        auto x = src[i];
+
+        auto xBitsInterpretedAsInt = bitCast<int32_t> (x);
+        auto mantissa = (xBitsInterpretedAsInt & Constants::c_0x007fffff);
+        auto mx = bitCast<float> (mantissa | Constants::c_0x3f000000);
+
+        auto y = static_cast<float> (xBitsInterpretedAsInt) * Constants::a;
+
+        auto dv = Constants::d / (Constants::e + mx);
+        auto ml = Constants::c * mx;
+
+        return y - Constants::b - ml - dv;
+    }
+
+    //==============================================================================
+    // AVX Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void prepareAVXEvaluation() const
+    requires (has::prepareAVXEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareAVXEvaluation();
+
+        c_a.avx = Expression::AVX::broadcast (Constants::a);
+        c_b.avx = Expression::AVX::broadcast (Constants::b);
+        c_c.avx = Expression::AVX::broadcast (Constants::c);
+        c_d.avx = Expression::AVX::broadcast (Constants::d);
+        c_e.avx = Expression::AVX::broadcast (Constants::e);
+
+        c_0x007fffff.avx = IntTypes::AVXSrc::broadcast (Constants::c_0x007fffff);
+        c_0x3f000000.avx = IntTypes::AVXSrc::broadcast (Constants::c_0x3f000000);
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") AVXRegister<value_type> getAVX (size_t i) const
+    requires (archX64 && has::getAVX<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto x = src.getAVX (i);
+
+        auto xBitsInterpretedAsInt = Expression::AVX::reinterpretAsInt (x);
+        auto mantissa = IntTypes::AVXSrc::bitwiseAndLegacy (xBitsInterpretedAsInt, c_0x007fffff.avx);
+        auto mx = IntTypes::AVXSrc::reinterpretAsFp (IntTypes::AVXSrc::bitwiseOrLegacy (mantissa, c_0x3f000000.avx));
+
+        auto y = Expression::AVX::mul (IntTypes::AVXSrc::convertToFp (xBitsInterpretedAsInt), c_a.avx);
+
+        auto dv = Expression::AVX::div (c_d.avx, Expression::AVX::add (c_e.avx, mx));
+        auto ml = Expression::AVX::mul (c_c.avx, mx);
+
+        return Expression::AVX::sub (Expression::AVX::sub (Expression::AVX::sub (y, c_b.avx), ml), dv);
+    }
+
+    //==============================================================================
+    // SSE Implementation
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void prepareSSEEvaluation() const
+    requires (has::prepareSSEEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareSSEEvaluation();
+
+        c_a.sse = Expression::SSE::broadcast (Constants::a);
+        c_b.sse = Expression::SSE::broadcast (Constants::b);
+        c_c.sse = Expression::SSE::broadcast (Constants::c);
+        c_d.sse = Expression::SSE::broadcast (Constants::d);
+        c_e.sse = Expression::SSE::broadcast (Constants::e);
+
+        c_0x007fffff.sse = IntTypes::SSESrc::broadcast (Constants::c_0x007fffff);
+        c_0x3f000000.sse = IntTypes::SSESrc::broadcast (Constants::c_0x3f000000);
+    }
+
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") SSERegister<value_type> getSSE (size_t i) const
+    requires (archX64 && has::getSSE<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto x = src.getSSE (i);
+
+        auto xBitsInterpretedAsInt = Expression::SSE::reinterpretAsInt (x);
+        auto mantissa = IntTypes::SSESrc::bitwiseAnd (xBitsInterpretedAsInt, c_0x007fffff.sse);
+        auto mx = IntTypes::SSESrc::reinterpretAsFp (IntTypes::SSESrc::bitwiseOr (mantissa, c_0x3f000000.sse));
+
+        auto y = Expression::SSE::mul (IntTypes::SSESrc::convertToFp (xBitsInterpretedAsInt), c_a.sse);
+
+        auto dv = Expression::SSE::div (c_d.sse, Expression::SSE::add (c_e.sse, mx));
+        auto ml = Expression::SSE::mul (c_c.sse, mx);
+
+        return Expression::SSE::sub (Expression::SSE::sub (Expression::SSE::sub (y, c_b.sse), ml), dv);
+    }
+
+    //==============================================================================
+    // Neon Implementation
+    void prepareNeonEvaluation() const
+    requires (archARM && has::prepareNeonEvaluation<SrcType> && Expression::CommonElement::isRealFloat)
+    {
+        src.prepareNeonEvaluation();
+
+        c_a.neon = Expression::Neon::broadcast (Constants::a);
+        c_b.neon = Expression::Neon::broadcast (Constants::b);
+        c_c.neon = Expression::Neon::broadcast (Constants::c);
+        c_d.neon = Expression::Neon::broadcast (Constants::d);
+        c_e.neon = Expression::Neon::broadcast (Constants::e);
+
+        c_0x007fffff.neon = IntTypes::NeonSrc::broadcast (Constants::c_0x007fffff);
+        c_0x3f000000.neon = IntTypes::NeonSrc::broadcast (Constants::c_0x3f000000);
+    }
+
+    NeonRegister<value_type> getNeon (size_t i) const
+    requires (archARM && has::getNeon<SrcType> && Expression::allElementTypesSame && Expression::CommonElement::isRealFloat)
+    {
+        auto x = src.getNeon (i);
+
+        auto xBitsInterpretedAsInt = Expression::Neon::reinterpretAsInt (x);
+        auto mantissa = IntTypes::NeonSrc::bitwiseAnd (xBitsInterpretedAsInt, c_0x007fffff.neon);
+        auto mx = IntTypes::NeonSrc::reinterpretAsFp (IntTypes::NeonSrc::bitwiseOr (mantissa, c_0x3f000000.neon));
+
+        auto y = Expression::Neon::mul (IntTypes::NeonSrc::convertToFp (xBitsInterpretedAsInt), c_a.neon);
+
+        auto dv = Expression::Neon::div (c_d.neon, Expression::Neon::add (c_e.neon, mx));
+        auto ml = Expression::Neon::mul (c_c.neon, mx);
+
+        return Expression::Neon::sub (Expression::Neon::sub (Expression::Neon::sub (y, c_b.neon), ml), dv);
+    }
+
+private:
+    struct IntTypes
+    {
+        using NeonSrc = NeonRegister<int32_t>;
+        using AVXSrc = AVXRegister<int32_t>;
+        using SSESrc = SSERegister<int32_t>;
+    };
+
+    mutable SIMDRegisterUnion<Expression> c_a;
+    mutable SIMDRegisterUnion<Expression> c_b;
+    mutable SIMDRegisterUnion<Expression> c_c;
+    mutable SIMDRegisterUnion<Expression> c_d;
+    mutable SIMDRegisterUnion<Expression> c_e;
+    mutable SIMDRegisterUnion<IntTypes> c_0x007fffff;
+    mutable SIMDRegisterUnion<IntTypes> c_0x3f000000;
+};
+
+} // namespace vctr::expressions
+
+namespace vctr
+{
+
+/** A fast approximation of the log2 function (e.g. 2 raised to the source elements) exploiting some low level details of the
+    binary representation of floating point values.
+
+    Limit the input values to -126 < x < 128 for 32 bit float and -1022.0 < x < 2024 for 64 bit double for a reasonable
+    approximation which should not exceed a relative error of 5.04e-5.
+
+    @ingroup Expressions
+ */
+constexpr inline ExpressionChainBuilder<expressions::FastLog2> fastLog2;
+
+} // namespace vctr

--- a/include/vctr/Miscellaneous/BitCast.h
+++ b/include/vctr/Miscellaneous/BitCast.h
@@ -1,0 +1,41 @@
+/*
+  ==============================================================================
+    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+    Copyright 2022- by sonible GmbH.
+
+    This file is part of VCTR - Versatile Container Templates Reconceptualized.
+
+    VCTR is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License version 3
+    only, as published by the Free Software Foundation.
+
+    VCTR is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License version 3 for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    version 3 along with VCTR.  If not, see <https://www.gnu.org/licenses/>.
+  ==============================================================================
+*/
+
+namespace vctr
+{
+
+#if __cpp_lib_bit_cast >= 201806L
+
+template <class To, class From>
+constexpr To bitCast (const From& from) noexcept { return std::bit_cast<To> (from); }
+
+#elif VCTR_CLANG && __has_builtin (__builtin_bit_cast)
+
+template <class To, class From>
+constexpr To bitCast (const From& from) noexcept { return __builtin_bit_cast (To, from); }
+
+#else
+
+#error "Your compiler has no bit_cast support"
+
+#endif
+}

--- a/include/vctr/SIMD/AVX/AVXRegister.h
+++ b/include/vctr/SIMD/AVX/AVXRegister.h
@@ -65,6 +65,8 @@ struct AVXRegister<float>
 
     //==============================================================================
     // Math
+    VCTR_TARGET ("avx") static AVXRegister floor (AVXRegister x)              { return { _mm256_floor_ps (x.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister ceil (AVXRegister x)               { return { _mm256_ceil_ps (x.value) }; }
     VCTR_TARGET ("avx") static AVXRegister mul (AVXRegister a, AVXRegister b) { return { _mm256_mul_ps (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_ps (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_ps (a.value, b.value) }; }
@@ -74,6 +76,10 @@ struct AVXRegister<float>
     VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_ps (a.value, b.value, c.value) }; }
     VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_ps (a.value, b.value, c.value) }; }
 
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("avx") static AVXRegister<int32_t> convertToInt (AVXRegister x);
+    VCTR_TARGET ("avx") static AVXRegister<int32_t> reinterpretAsInt (AVXRegister x);
     // clang-format on
 };
 
@@ -112,6 +118,8 @@ struct AVXRegister<double>
 
     //==============================================================================
     // Math
+    VCTR_TARGET ("avx") static AVXRegister floor (AVXRegister x)              { return { _mm256_floor_pd (x.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister ceil (AVXRegister x)               { return { _mm256_ceil_pd (x.value) }; }
     VCTR_TARGET ("avx") static AVXRegister mul (AVXRegister a, AVXRegister b) { return { _mm256_mul_pd (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_pd (a.value, b.value) }; }
     VCTR_TARGET ("avx") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_pd (a.value, b.value) }; }
@@ -120,6 +128,11 @@ struct AVXRegister<double>
     VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_pd (a.value, b.value) }; }
     VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_pd (a.value, b.value, c.value) }; }
     VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_pd (a.value, b.value, c.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("avx512vl") VCTR_TARGET ("avx512dq") static AVXRegister<int64_t> convertToInt (AVXRegister x);
+    VCTR_TARGET ("avx") static AVXRegister<int64_t> reinterpretAsInt (AVXRegister x);
     // clang-format on
 };
 
@@ -146,6 +159,12 @@ struct AVXRegister<int32_t>
 
     //==============================================================================
     // Bit Operations
+    VCTR_TARGET ("avx2") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_si256 (a.value, b.value) }; }
+    VCTR_TARGET ("avx2") static AVXRegister bitwiseOr (AVXRegister a, AVXRegister b) { return { _mm256_or_si256 (a.value, b.value) }; }
+    // These are non AVX2 variants that might be used in functions that are not targeted AVX2 at the expense of slightly worse performance
+    VCTR_TARGET ("avx") static AVXRegister bitwiseAndLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castps_si256 (_mm256_and_ps (_mm256_castsi256_ps (a.value), _mm256_castsi256_ps (b.value))) }; }
+    VCTR_TARGET ("avx") static AVXRegister bitwiseOrLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castps_si256 (_mm256_or_ps (_mm256_castsi256_ps (a.value), _mm256_castsi256_ps (b.value))) }; }
+
 
     //==============================================================================
     // Math
@@ -154,6 +173,11 @@ struct AVXRegister<int32_t>
     VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi32 (a.value, b.value) }; }
     VCTR_TARGET ("avx2") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_epi32 (a.value, b.value) }; }
     VCTR_TARGET ("avx2") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_epi32 (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("avx") static AVXRegister<float> convertToFp (AVXRegister x)     { return { _mm256_cvtepi32_ps (x.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister<float> reinterpretAsFp (AVXRegister x) { return { _mm256_castsi256_ps (x.value) }; }
     // clang-format on
 };
 
@@ -213,11 +237,21 @@ struct AVXRegister<int64_t>
 
     //==============================================================================
     // Bit Operations
+    VCTR_TARGET ("avx2") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_si256 (a.value, b.value) }; }
+    VCTR_TARGET ("avx2") static AVXRegister bitwiseOr (AVXRegister a, AVXRegister b) { return { _mm256_or_si256 (a.value, b.value) }; }
+    // These are non AVX2 variants that might be used in functions that are not targeted AVX2 at the expense of slightly worse performance
+    VCTR_TARGET ("avx") static AVXRegister bitwiseAndLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castpd_si256 (_mm256_and_pd (_mm256_castsi256_pd (a.value), _mm256_castsi256_pd (b.value))) }; }
+    VCTR_TARGET ("avx") static AVXRegister bitwiseOrLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castpd_si256 (_mm256_or_pd (_mm256_castsi256_pd (a.value), _mm256_castsi256_pd (b.value))) }; }
 
     //==============================================================================
     // Math
     VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi64 (a.value, b.value) }; }
     VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi64 (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("avx") static AVXRegister<double> convertToFp (AVXRegister x)     { return { _mm256_cvtepi64_pd (x.value) }; }
+    VCTR_TARGET ("avx") static AVXRegister<double> reinterpretAsFp (AVXRegister x) { return { _mm256_castsi256_pd (x.value) }; }
     // clang-format on
 };
 
@@ -252,6 +286,10 @@ struct AVXRegister<uint64_t>
     // clang-format on
 };
 
+inline AVXRegister<int32_t> AVXRegister<float>::convertToInt (AVXRegister x)      { return { _mm256_cvtps_epi32 (x.value) }; }
+inline AVXRegister<int32_t> AVXRegister<float>::reinterpretAsInt (AVXRegister x)  { return { _mm256_castps_si256 (x.value) }; }
+inline AVXRegister<int64_t> AVXRegister<double>::convertToInt (AVXRegister x)      { return { _mm256_cvtpd_epi64 (x.value) }; }
+inline AVXRegister<int64_t> AVXRegister<double>::reinterpretAsInt (AVXRegister x)  { return { _mm256_castpd_si256 (x.value) }; }
 #endif
 
 } // namespace vctr

--- a/include/vctr/SIMD/AVX/AVXRegister.h
+++ b/include/vctr/SIMD/AVX/AVXRegister.h
@@ -41,45 +41,45 @@ struct AVXRegister<float>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const float* d)                             { return { _mm256_loadu_ps (d) }; }
-    VCTR_TARGET ("avx") static AVXRegister loadAligned   (const float* d)                             { return { _mm256_load_ps (d) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (float x)                                    { return { _mm256_broadcast_ss (&x) }; }
-    VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<float> a, SSERegister<float> b) { return { _mm256_set_m128 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const float* d)                             { return { _mm256_loadu_ps (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadAligned   (const float* d)                             { return { _mm256_load_ps (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister broadcast     (float x)                                    { return { _mm256_broadcast_ss (&x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<float> a, SSERegister<float> b) { return { _mm256_set_m128 (a.value, b.value) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("avx") void storeUnaligned (float* d) const { _mm256_storeu_ps (d, value); }
-    VCTR_TARGET ("avx") void storeAligned   (float* d) const { _mm256_store_ps  (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeUnaligned (float* d) const { _mm256_storeu_ps (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeAligned   (float* d) const { _mm256_store_ps  (d, value); }
 
     //==============================================================================
     // Generate Compare Masks
     template <CompareOp Op>
-    VCTR_TARGET ("avx") static AVXRegister compare (AVXRegister a, AVXRegister b) { return { _mm256_cmp_ps (a.value, b.value, int (Op)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister compare (AVXRegister a, AVXRegister b) { return { _mm256_cmp_ps (a.value, b.value, int (Op)) }; }
 
     //==============================================================================
     // Bit Operations
     /** Evaluates a & (! b) - so b is negated. */
-    VCTR_TARGET ("avx") static AVXRegister bitwiseAndNot (AVXRegister a, AVXRegister b) { return { _mm256_andnot_ps (b.value, a.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister bitwiseBlend (AVXRegister a, AVXRegister b, AVXRegister mask) { return { _mm256_blendv_ps (a.value, b.value, mask.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseAndNot (AVXRegister a, AVXRegister b) { return { _mm256_andnot_ps (b.value, a.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseBlend (AVXRegister a, AVXRegister b, AVXRegister mask) { return { _mm256_blendv_ps (a.value, b.value, mask.value) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("avx") static AVXRegister floor (AVXRegister x)              { return { _mm256_floor_ps (x.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister ceil (AVXRegister x)               { return { _mm256_ceil_ps (x.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister mul (AVXRegister a, AVXRegister b) { return { _mm256_mul_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_ps (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_ps (a.value, b.value) }; }
-    VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_ps (a.value, b.value, c.value) }; }
-    VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_ps (a.value, b.value, c.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister floor (AVXRegister x)              { return { _mm256_floor_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister ceil (AVXRegister x)               { return { _mm256_ceil_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister mul (AVXRegister a, AVXRegister b) { return { _mm256_mul_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_ps (a.value, b.value, c.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_ps (a.value, b.value, c.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("avx") static AVXRegister<int32_t> convertToInt (AVXRegister x);
-    VCTR_TARGET ("avx") static AVXRegister<int32_t> reinterpretAsInt (AVXRegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<int32_t> convertToInt (AVXRegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<int32_t> reinterpretAsInt (AVXRegister x);
     // clang-format on
 };
 
@@ -94,45 +94,45 @@ struct AVXRegister<double>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const double* d)                              { return { _mm256_loadu_pd (d) }; }
-    VCTR_TARGET ("avx") static AVXRegister loadAligned   (const double* d)                              { return { _mm256_load_pd (d) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (double x)                                     { return { _mm256_broadcast_sd (&x) }; }
-    VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<double> a, SSERegister<double> b) { return { _mm256_set_m128d (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const double* d)                              { return { _mm256_loadu_pd (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadAligned   (const double* d)                              { return { _mm256_load_pd (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister broadcast     (double x)                                     { return { _mm256_broadcast_sd (&x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<double> a, SSERegister<double> b) { return { _mm256_set_m128d (a.value, b.value) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("avx") void storeUnaligned (double* d) const { _mm256_storeu_pd (d, value); }
-    VCTR_TARGET ("avx") void storeAligned   (double* d) const { _mm256_store_pd (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeUnaligned (double* d) const { _mm256_storeu_pd (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeAligned   (double* d) const { _mm256_store_pd (d, value); }
 
     //==============================================================================
     // Generate Compare Masks
     template <CompareOp Op>
-    VCTR_TARGET ("avx") static AVXRegister compare (AVXRegister a, AVXRegister b) { return { _mm256_cmp_pd (a.value, b.value, int (Op)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister compare (AVXRegister a, AVXRegister b) { return { _mm256_cmp_pd (a.value, b.value, int (Op)) }; }
 
     //==============================================================================
     // Bit Operations
     /** Evaluates a & (! b) - so b is negated. */
-    VCTR_TARGET ("avx") static AVXRegister bitwiseAndNot (AVXRegister a, AVXRegister b) { return { _mm256_andnot_pd (b.value, a.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister bitwiseBlend (AVXRegister a, AVXRegister b, AVXRegister mask) { return { _mm256_blendv_pd (a.value, b.value, mask.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseAndNot (AVXRegister a, AVXRegister b) { return { _mm256_andnot_pd (b.value, a.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseBlend (AVXRegister a, AVXRegister b, AVXRegister mask) { return { _mm256_blendv_pd (a.value, b.value, mask.value) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("avx") static AVXRegister floor (AVXRegister x)              { return { _mm256_floor_pd (x.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister ceil (AVXRegister x)               { return { _mm256_ceil_pd (x.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister mul (AVXRegister a, AVXRegister b) { return { _mm256_mul_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_pd (a.value, b.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_pd (a.value, b.value) }; }
-    VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_pd (a.value, b.value, c.value) }; }
-    VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_pd (a.value, b.value, c.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister floor (AVXRegister x)              { return { _mm256_floor_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister ceil (AVXRegister x)               { return { _mm256_ceil_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister mul (AVXRegister a, AVXRegister b) { return { _mm256_mul_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister div (AVXRegister a, AVXRegister b) { return { _mm256_div_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") static AVXRegister fma (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fmadd_pd (a.value, b.value, c.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("fma") static AVXRegister fms (AVXRegister a, AVXRegister b, AVXRegister c) { return { _mm256_fnmadd_pd (a.value, b.value, c.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("avx512vl") VCTR_TARGET ("avx512dq") static AVXRegister<int64_t> convertToInt (AVXRegister x);
-    VCTR_TARGET ("avx") static AVXRegister<int64_t> reinterpretAsInt (AVXRegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx512vl") VCTR_TARGET ("avx512dq") static AVXRegister<int64_t> convertToInt (AVXRegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<int64_t> reinterpretAsInt (AVXRegister x);
     // clang-format on
 };
 
@@ -147,37 +147,37 @@ struct AVXRegister<int32_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const int32_t* d)                               { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister loadAligned   (const int32_t* d)                               { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (int32_t x)                                      { return { _mm256_set1_epi32 (x) }; }
-    VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<int32_t> a, SSERegister<int32_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const int32_t* d)                               { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadAligned   (const int32_t* d)                               { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister broadcast     (int32_t x)                                      { return { _mm256_set1_epi32 (x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<int32_t> a, SSERegister<int32_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("avx") void storeUnaligned (int32_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
-    VCTR_TARGET ("avx") void storeAligned   (int32_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeUnaligned (int32_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeAligned   (int32_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
-    VCTR_TARGET ("avx2") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_si256 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister bitwiseOr (AVXRegister a, AVXRegister b) { return { _mm256_or_si256 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_si256 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister bitwiseOr (AVXRegister a, AVXRegister b) { return { _mm256_or_si256 (a.value, b.value) }; }
     // These are non AVX2 variants that might be used in functions that are not targeted AVX2 at the expense of slightly worse performance
-    VCTR_TARGET ("avx") static AVXRegister bitwiseAndLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castps_si256 (_mm256_and_ps (_mm256_castsi256_ps (a.value), _mm256_castsi256_ps (b.value))) }; }
-    VCTR_TARGET ("avx") static AVXRegister bitwiseOrLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castps_si256 (_mm256_or_ps (_mm256_castsi256_ps (a.value), _mm256_castsi256_ps (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseAndLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castps_si256 (_mm256_and_ps (_mm256_castsi256_ps (a.value), _mm256_castsi256_ps (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseOrLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castps_si256 (_mm256_or_ps (_mm256_castsi256_ps (a.value), _mm256_castsi256_ps (b.value))) }; }
 
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("avx2") static AVXRegister abs (AVXRegister x)                { return { _mm256_abs_epi32 (x.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister abs (AVXRegister x)                { return { _mm256_abs_epi32 (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_epi32 (a.value, b.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("avx") static AVXRegister<float> convertToFp (AVXRegister x)     { return { _mm256_cvtepi32_ps (x.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister<float> reinterpretAsFp (AVXRegister x) { return { _mm256_castsi256_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<float> convertToFp (AVXRegister x)     { return { _mm256_cvtepi32_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<float> reinterpretAsFp (AVXRegister x) { return { _mm256_castsi256_ps (x.value) }; }
     // clang-format on
 };
 
@@ -192,25 +192,25 @@ struct AVXRegister<uint32_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const uint32_t* d)                                { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister loadAligned   (const uint32_t* d)                                { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (uint32_t x)                                       { return { _mm256_set1_epi32 ((int32_t) x) }; }
-    VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<uint32_t> a, SSERegister<uint32_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const uint32_t* d)                                { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadAligned   (const uint32_t* d)                                { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister broadcast     (uint32_t x)                                       { return { _mm256_set1_epi32 ((int32_t) x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<uint32_t> a, SSERegister<uint32_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("avx") void storeUnaligned (uint32_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
-    VCTR_TARGET ("avx") void storeAligned   (uint32_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeUnaligned (uint32_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeAligned   (uint32_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_epu32 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_epu32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister max (AVXRegister a, AVXRegister b) { return { _mm256_max_epu32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister min (AVXRegister a, AVXRegister b) { return { _mm256_min_epu32 (a.value, b.value) }; }
     // clang-format on
 };
 
@@ -225,33 +225,33 @@ struct AVXRegister<int64_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const int64_t* d)                               { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister loadAligned   (const int64_t* d)                               { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (int64_t x)                                      { return { _mm256_set1_epi64x (x) }; }
-    VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<int64_t> a, SSERegister<int64_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const int64_t* d)                               { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadAligned   (const int64_t* d)                               { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister broadcast     (int64_t x)                                      { return { _mm256_set1_epi64x (x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<int64_t> a, SSERegister<int64_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("avx") void storeUnaligned (int64_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
-    VCTR_TARGET ("avx") void storeAligned   (int64_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeUnaligned (int64_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeAligned   (int64_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
-    VCTR_TARGET ("avx2") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_si256 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister bitwiseOr (AVXRegister a, AVXRegister b) { return { _mm256_or_si256 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister bitwiseAnd (AVXRegister a, AVXRegister b) { return { _mm256_and_si256 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister bitwiseOr (AVXRegister a, AVXRegister b) { return { _mm256_or_si256 (a.value, b.value) }; }
     // These are non AVX2 variants that might be used in functions that are not targeted AVX2 at the expense of slightly worse performance
-    VCTR_TARGET ("avx") static AVXRegister bitwiseAndLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castpd_si256 (_mm256_and_pd (_mm256_castsi256_pd (a.value), _mm256_castsi256_pd (b.value))) }; }
-    VCTR_TARGET ("avx") static AVXRegister bitwiseOrLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castpd_si256 (_mm256_or_pd (_mm256_castsi256_pd (a.value), _mm256_castsi256_pd (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseAndLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castpd_si256 (_mm256_and_pd (_mm256_castsi256_pd (a.value), _mm256_castsi256_pd (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister bitwiseOrLegacy (AVXRegister a, AVXRegister b) { return { _mm256_castpd_si256 (_mm256_or_pd (_mm256_castsi256_pd (a.value), _mm256_castsi256_pd (b.value))) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi64 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi64 (a.value, b.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("avx") static AVXRegister<double> convertToFp (AVXRegister x)     { return { _mm256_cvtepi64_pd (x.value) }; }
-    VCTR_TARGET ("avx") static AVXRegister<double> reinterpretAsFp (AVXRegister x) { return { _mm256_castsi256_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<double> convertToFp (AVXRegister x)     { return { _mm256_cvtepi64_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister<double> reinterpretAsFp (AVXRegister x) { return { _mm256_castsi256_pd (x.value) }; }
     // clang-format on
 };
 
@@ -266,23 +266,23 @@ struct AVXRegister<uint64_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const uint64_t* d)                                { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister loadAligned   (const uint64_t* d)                                { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
-    VCTR_TARGET ("avx") static AVXRegister broadcast     (uint64_t x)                                       { return { _mm256_set1_epi64x ((int64_t) x) }; }
-    VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<uint64_t> a, SSERegister<uint64_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadUnaligned (const uint64_t* d)                                { return { _mm256_loadu_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister loadAligned   (const uint64_t* d)                                { return { _mm256_load_si256 (reinterpret_cast<const __m256i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister broadcast     (uint64_t x)                                       { return { _mm256_set1_epi64x ((int64_t) x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") static AVXRegister fromSSE       (SSERegister<uint64_t> a, SSERegister<uint64_t> b) { return { _mm256_set_m128i (a.value, b.value) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("avx") void storeUnaligned (uint64_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
-    VCTR_TARGET ("avx") void storeAligned   (uint64_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeUnaligned (uint64_t* d) const { _mm256_storeu_si256 (reinterpret_cast<__m256i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx") void storeAligned   (uint64_t* d) const { _mm256_store_si256  (reinterpret_cast<__m256i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi64 (a.value, b.value) }; }
-    VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister add (AVXRegister a, AVXRegister b) { return { _mm256_add_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx2") static AVXRegister sub (AVXRegister a, AVXRegister b) { return { _mm256_sub_epi64 (a.value, b.value) }; }
     // clang-format on
 };
 

--- a/include/vctr/SIMD/Neon/NeonRegister.h
+++ b/include/vctr/SIMD/Neon/NeonRegister.h
@@ -86,6 +86,8 @@ struct NeonRegister<float>
     //==============================================================================
     // Math
     static NeonRegister abs (NeonRegister x)                 { return { vabsq_f32 (x.value) }; }
+    static NeonRegister floor (NeonRegister x)               { return { vrndmq_f32 (x.value) }; }
+    static NeonRegister ceil (NeonRegister x)                { return { vrndpq_f32 (x.value) }; }
     static NeonRegister mul (NeonRegister a, NeonRegister b) { return { vmulq_f32 (a.value, b.value) }; }
     static NeonRegister div (NeonRegister a, NeonRegister b) { return { vdivq_f32 (a.value, b.value) }; }
     static NeonRegister add (NeonRegister a, NeonRegister b) { return { vaddq_f32 (a.value, b.value) }; }
@@ -94,6 +96,11 @@ struct NeonRegister<float>
     static NeonRegister min (NeonRegister a, NeonRegister b) { return { vminq_f32 (a.value, b.value) }; }
     static NeonRegister fma (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmaq_f32 (c.value, a.value, b.value) }; }
     static NeonRegister fms (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmsq_f32 (c.value, a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    static NeonRegister<int32_t> convertToInt (NeonRegister x);
+    static NeonRegister<int32_t> reinterpretAsInt (NeonRegister x);
     // clang-format on
 };
 
@@ -130,6 +137,8 @@ struct NeonRegister<double>
     //==============================================================================
     // Math
     static NeonRegister abs (NeonRegister x)                 { return { vabsq_f64 (x.value) }; }
+    static NeonRegister floor (NeonRegister x)               { return { vrndmq_f64 (x.value) }; }
+    static NeonRegister ceil (NeonRegister x)                { return { vrndpq_f64 (x.value) }; }
     static NeonRegister mul (NeonRegister a, NeonRegister b) { return { vmulq_f64 (a.value, b.value) }; }
     static NeonRegister div (NeonRegister a, NeonRegister b) { return { vdivq_f64 (a.value, b.value) }; }
     static NeonRegister add (NeonRegister a, NeonRegister b) { return { vaddq_f64 (a.value, b.value) }; }
@@ -138,6 +147,11 @@ struct NeonRegister<double>
     static NeonRegister min (NeonRegister a, NeonRegister b) { return { vminq_f64 (a.value, b.value) }; }
     static NeonRegister fma (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmaq_f64 (c.value, a.value, b.value) }; }
     static NeonRegister fms (NeonRegister a, NeonRegister b, NeonRegister c) { return { vfmsq_f64 (c.value, a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    static NeonRegister<int64_t> convertToInt (NeonRegister x);
+    static NeonRegister<int64_t> reinterpretAsInt (NeonRegister x);
     // clang-format on
 };
 
@@ -161,6 +175,8 @@ struct NeonRegister<int32_t>
 
     //==============================================================================
     // Bit Operations
+    static NeonRegister bitwiseAnd (NeonRegister a, NeonRegister b) { return { vandq_s32 (a.value, b.value) }; }
+    static NeonRegister bitwiseOr  (NeonRegister a, NeonRegister b) { return { vorrq_s32 (a.value, b.value) }; }
 
     //==============================================================================
     // Math
@@ -170,6 +186,11 @@ struct NeonRegister<int32_t>
     static NeonRegister sub (NeonRegister a, NeonRegister b) { return { vsubq_s32 (a.value, b.value) }; }
     static NeonRegister max (NeonRegister a, NeonRegister b) { return { vmaxq_s32 (a.value, b.value) }; }
     static NeonRegister min (NeonRegister a, NeonRegister b) { return { vminq_s32 (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    static NeonRegister<float> convertToFp (NeonRegister x)     { return { vcvtq_f32_s32 (x.value) }; }
+    static NeonRegister<float> reinterpretAsFp (NeonRegister x) { return { vreinterpretq_f32_s32 (x.value) }; }
     // clang-format on
 };
 
@@ -193,6 +214,8 @@ struct NeonRegister<uint32_t>
 
     //==============================================================================
     // Bit Operations
+    static NeonRegister bitwiseAnd (NeonRegister a, NeonRegister b) { return { vandq_u32 (a.value, b.value) }; }
+    static NeonRegister bitwiseOr  (NeonRegister a, NeonRegister b) { return { vorrq_u32 (a.value, b.value) }; }
 
     //==============================================================================
     // Math
@@ -224,12 +247,19 @@ struct NeonRegister<int64_t>
 
     //==============================================================================
     // Bit Operations
+    static NeonRegister bitwiseAnd (NeonRegister a, NeonRegister b) { return { vandq_s64 (a.value, b.value) }; }
+    static NeonRegister bitwiseOr  (NeonRegister a, NeonRegister b) { return { vorrq_s64 (a.value, b.value) }; }
 
     //==============================================================================
     // Math
     static NeonRegister abs (NeonRegister x)                 { return { vabsq_s64 (x.value) }; }
     static NeonRegister add (NeonRegister a, NeonRegister b) { return { vaddq_s64 (a.value, b.value) }; }
     static NeonRegister sub (NeonRegister a, NeonRegister b) { return { vsubq_s64 (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    static NeonRegister<double> convertToFp (NeonRegister x)     { return { vcvtq_f64_s64 (x.value) }; }
+    static NeonRegister<double> reinterpretAsFp (NeonRegister x) { return { vreinterpretq_f64_s64 (x.value) }; }
     // clang-format on
 };
 
@@ -253,6 +283,8 @@ struct NeonRegister<uint64_t>
 
     //==============================================================================
     // Bit Operations
+    static NeonRegister bitwiseAnd (NeonRegister a, NeonRegister b) { return { vandq_u64 (a.value, b.value) }; }
+    static NeonRegister bitwiseOr  (NeonRegister a, NeonRegister b) { return { vorrq_u64 (a.value, b.value) }; }
 
     //==============================================================================
     // Math
@@ -260,6 +292,11 @@ struct NeonRegister<uint64_t>
     static NeonRegister sub (NeonRegister a, NeonRegister b) { return { vsubq_u64 (a.value, b.value) }; }
     // clang-format on
 };
+
+inline NeonRegister<int32_t> NeonRegister<float>::convertToInt (NeonRegister<float> x)       { return { vcvtq_s32_f32 (x.value) }; }
+inline NeonRegister<int32_t> NeonRegister<float>::reinterpretAsInt (NeonRegister<float> x)   { return { vreinterpretq_s32_f32 (x.value) }; }
+inline NeonRegister<int64_t> NeonRegister<double>::convertToInt (NeonRegister<double> x)     { return { vcvtq_s64_f64 (x.value) }; }
+inline NeonRegister<int64_t> NeonRegister<double>::reinterpretAsInt (NeonRegister<double> x) { return { vreinterpretq_s64_f64 (x.value) }; }
 
 #endif
 

--- a/include/vctr/SIMD/SSE/SSERegister.h
+++ b/include/vctr/SIMD/SSE/SSERegister.h
@@ -58,12 +58,19 @@ struct SSERegister<float>
 
     //==============================================================================
     // Math
+    VCTR_TARGET ("sse4.1") static SSERegister floor (SSERegister x)              { return { _mm_floor_ps (x.value) }; }
+    VCTR_TARGET ("sse4.1") static SSERegister ceil (SSERegister x)               { return { _mm_ceil_ps (x.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister mul (SSERegister a, SSERegister b) { return { _mm_mul_ps (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister div (SSERegister a, SSERegister b) { return { _mm_div_ps (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_ps (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_ps (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_ps (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_ps (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("sse4.1") static SSERegister<int32_t> convertToInt (SSERegister x);
+    VCTR_TARGET ("sse4.1") static SSERegister<int32_t> reinterpretAsInt (SSERegister x);
     // clang-format on
 };
 
@@ -94,12 +101,19 @@ struct SSERegister<double>
 
     //==============================================================================
     // Math
+    VCTR_TARGET ("sse4.1") static SSERegister floor (SSERegister x)              { return { _mm_floor_pd (x.value) }; }
+    VCTR_TARGET ("sse4.1") static SSERegister ceil (SSERegister x)               { return { _mm_ceil_pd (x.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister mul (SSERegister a, SSERegister b) { return { _mm_mul_pd (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister div (SSERegister a, SSERegister b) { return { _mm_div_pd (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_pd (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_pd (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_pd (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_pd (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("avx512vl") VCTR_TARGET ("avx512dq") static SSERegister<int64_t> convertToInt (SSERegister x);
+    VCTR_TARGET ("sse4.1") static SSERegister<int64_t> reinterpretAsInt (SSERegister x);
     // clang-format on
 };
 
@@ -125,6 +139,8 @@ struct SSERegister<int32_t>
 
     //==============================================================================
     // Bit Operations
+    VCTR_TARGET ("sse4.1") static SSERegister bitwiseAnd (SSERegister a, SSERegister b) { return { _mm_castps_si128 (_mm_and_ps (_mm_castsi128_ps (a.value), _mm_castsi128_ps (b.value))) }; }
+    VCTR_TARGET ("sse4.1") static SSERegister bitwiseOr (SSERegister a, SSERegister b) { return { _mm_castps_si128 (_mm_or_ps (_mm_castsi128_ps (a.value), _mm_castsi128_ps (b.value))) }; }
 
     //==============================================================================
     // Math
@@ -133,6 +149,11 @@ struct SSERegister<int32_t>
     VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi32 (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_epi32 (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_epi32 (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("sse4.1") static SSERegister<float> convertToFp (SSERegister x)     { return { _mm_cvtepi32_ps (x.value) }; }
+    VCTR_TARGET ("sse4.1") static SSERegister<float> reinterpretAsFp (SSERegister x) { return { _mm_castsi128_ps (x.value) }; }
     // clang-format on
 };
 
@@ -190,11 +211,18 @@ struct SSERegister<int64_t>
 
     //==============================================================================
     // Bit Operations
+    VCTR_TARGET ("sse4.1") static SSERegister bitwiseAnd (SSERegister a, SSERegister b) { return { _mm_castpd_si128 (_mm_and_pd (_mm_castsi128_pd (a.value), _mm_castsi128_pd (b.value))) }; }
+    VCTR_TARGET ("sse4.1") static SSERegister bitwiseOr (SSERegister a, SSERegister b) { return { _mm_castpd_si128 (_mm_or_pd (_mm_castsi128_pd (a.value), _mm_castsi128_pd (b.value))) }; }
 
     //==============================================================================
     // Math
     VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi64 (a.value, b.value) }; }
     VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi64 (a.value, b.value) }; }
+
+    //==============================================================================
+    // Type conversion
+    VCTR_TARGET ("sse4.1") static SSERegister<double> convertToFp (SSERegister x)     { return { _mm_cvtepi64_pd (x.value) }; }
+    VCTR_TARGET ("sse4.1") static SSERegister<double> reinterpretAsFp (SSERegister x) { return { _mm_castsi128_pd (x.value) }; }
     // clang-format on
 };
 
@@ -227,6 +255,11 @@ struct SSERegister<uint64_t>
     VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi64 (a.value, b.value) }; }
     // clang-format on
 };
+
+inline SSERegister<int32_t> SSERegister<float>::convertToInt (SSERegister x)      { return { _mm_cvtps_epi32 (x.value) }; }
+inline SSERegister<int32_t> SSERegister<float>::reinterpretAsInt (SSERegister x)  { return { _mm_castps_si128 (x.value) }; }
+inline SSERegister<int64_t> SSERegister<double>::convertToInt (SSERegister x)     { return { _mm_cvtpd_epi64 (x.value) }; }
+inline SSERegister<int64_t> SSERegister<double>::reinterpretAsInt (SSERegister x) { return { _mm_castpd_si128 (x.value) }; }
 
 #endif
 

--- a/include/vctr/SIMD/SSE/SSERegister.h
+++ b/include/vctr/SIMD/SSE/SSERegister.h
@@ -42,35 +42,35 @@ struct SSERegister<float>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const float* d)  { return { _mm_loadu_ps (d) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const float* d)  { return { _mm_load_ps (d) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister broadcast     (float x)         { return { _mm_load1_ps (&x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const float* d)  { return { _mm_loadu_ps (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const float* d)  { return { _mm_load_ps (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister broadcast     (float x)         { return { _mm_load1_ps (&x) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("sse4.1") void storeUnaligned (float* d) const { _mm_storeu_ps (d, value); }
-    VCTR_TARGET ("sse4.1") void storeAligned   (float* d) const { _mm_store_ps (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeUnaligned (float* d) const { _mm_storeu_ps (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeAligned   (float* d) const { _mm_store_ps (d, value); }
 
     //==============================================================================
     // Bit Operations
     /** Evaluates a & (! b) - so b is negated. */
-    VCTR_TARGET ("sse4.1") static SSERegister bitwiseAndNot (SSERegister a, SSERegister b) { return { _mm_andnot_ps (b.value, a.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister bitwiseAndNot (SSERegister a, SSERegister b) { return { _mm_andnot_ps (b.value, a.value) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("sse4.1") static SSERegister floor (SSERegister x)              { return { _mm_floor_ps (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister ceil (SSERegister x)               { return { _mm_ceil_ps (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister mul (SSERegister a, SSERegister b) { return { _mm_mul_ps (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister div (SSERegister a, SSERegister b) { return { _mm_div_ps (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_ps (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_ps (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_ps (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister floor (SSERegister x)              { return { _mm_floor_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister ceil (SSERegister x)               { return { _mm_ceil_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister mul (SSERegister a, SSERegister b) { return { _mm_mul_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister div (SSERegister a, SSERegister b) { return { _mm_div_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_ps (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_ps (a.value, b.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("sse4.1") static SSERegister<int32_t> convertToInt (SSERegister x);
-    VCTR_TARGET ("sse4.1") static SSERegister<int32_t> reinterpretAsInt (SSERegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<int32_t> convertToInt (SSERegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<int32_t> reinterpretAsInt (SSERegister x);
     // clang-format on
 };
 
@@ -85,35 +85,35 @@ struct SSERegister<double>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const double* d)  { return { _mm_loadu_pd (d) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const double* d)  { return { _mm_load_pd (d) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister broadcast     (double x)         { return { _mm_load1_pd (&x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const double* d)  { return { _mm_loadu_pd (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const double* d)  { return { _mm_load_pd (d) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister broadcast     (double x)         { return { _mm_load1_pd (&x) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("sse4.1") void storeUnaligned (double* d) const { _mm_storeu_pd (d, value); }
-    VCTR_TARGET ("sse4.1") void storeAligned   (double* d) const { _mm_store_pd (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeUnaligned (double* d) const { _mm_storeu_pd (d, value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeAligned   (double* d) const { _mm_store_pd (d, value); }
 
     //==============================================================================
     // Bit Operations
     /** Evaluates a & (! b) - so b is negated. */
-    VCTR_TARGET ("sse4.1") static SSERegister bitwiseAndNot (SSERegister a, SSERegister b) { return { _mm_andnot_pd (b.value, a.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister bitwiseAndNot (SSERegister a, SSERegister b) { return { _mm_andnot_pd (b.value, a.value) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("sse4.1") static SSERegister floor (SSERegister x)              { return { _mm_floor_pd (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister ceil (SSERegister x)               { return { _mm_ceil_pd (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister mul (SSERegister a, SSERegister b) { return { _mm_mul_pd (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister div (SSERegister a, SSERegister b) { return { _mm_div_pd (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_pd (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_pd (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_pd (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister floor (SSERegister x)              { return { _mm_floor_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister ceil (SSERegister x)               { return { _mm_ceil_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister mul (SSERegister a, SSERegister b) { return { _mm_mul_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister div (SSERegister a, SSERegister b) { return { _mm_div_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_pd (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_pd (a.value, b.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("avx512vl") VCTR_TARGET ("avx512dq") static SSERegister<int64_t> convertToInt (SSERegister x);
-    VCTR_TARGET ("sse4.1") static SSERegister<int64_t> reinterpretAsInt (SSERegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("avx512vl") VCTR_TARGET ("avx512dq") static SSERegister<int64_t> convertToInt (SSERegister x);
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<int64_t> reinterpretAsInt (SSERegister x);
     // clang-format on
 };
 
@@ -128,32 +128,32 @@ struct SSERegister<int32_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const int32_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const int32_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister broadcast     (int32_t x)         { return { _mm_set1_epi32 (x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const int32_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const int32_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister broadcast     (int32_t x)         { return { _mm_set1_epi32 (x) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("sse4.1") void storeUnaligned (int32_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
-    VCTR_TARGET ("sse4.1") void storeAligned (int32_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeUnaligned (int32_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeAligned (int32_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
-    VCTR_TARGET ("sse4.1") static SSERegister bitwiseAnd (SSERegister a, SSERegister b) { return { _mm_castps_si128 (_mm_and_ps (_mm_castsi128_ps (a.value), _mm_castsi128_ps (b.value))) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister bitwiseOr (SSERegister a, SSERegister b) { return { _mm_castps_si128 (_mm_or_ps (_mm_castsi128_ps (a.value), _mm_castsi128_ps (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister bitwiseAnd (SSERegister a, SSERegister b) { return { _mm_castps_si128 (_mm_and_ps (_mm_castsi128_ps (a.value), _mm_castsi128_ps (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister bitwiseOr (SSERegister a, SSERegister b) { return { _mm_castps_si128 (_mm_or_ps (_mm_castsi128_ps (a.value), _mm_castsi128_ps (b.value))) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("sse4.1") static SSERegister abs (SSERegister x)                { return { _mm_abs_epi32 (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister abs (SSERegister x)                { return { _mm_abs_epi32 (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_epi32 (a.value, b.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("sse4.1") static SSERegister<float> convertToFp (SSERegister x)     { return { _mm_cvtepi32_ps (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister<float> reinterpretAsFp (SSERegister x) { return { _mm_castsi128_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<float> convertToFp (SSERegister x)     { return { _mm_cvtepi32_ps (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<float> reinterpretAsFp (SSERegister x) { return { _mm_castsi128_ps (x.value) }; }
     // clang-format on
 };
 
@@ -168,24 +168,24 @@ struct SSERegister<uint32_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const uint32_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const uint32_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister broadcast     (uint32_t x)         { return { _mm_set1_epi32 ((int32_t) x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const uint32_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const uint32_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister broadcast     (uint32_t x)         { return { _mm_set1_epi32 ((int32_t) x) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("sse4.1") void storeUnaligned (uint32_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
-    VCTR_TARGET ("sse4.1") void storeAligned (uint32_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeUnaligned (uint32_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeAligned (uint32_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi32 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_epu32 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_epu32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister max (SSERegister a, SSERegister b) { return { _mm_max_epu32 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister min (SSERegister a, SSERegister b) { return { _mm_min_epu32 (a.value, b.value) }; }
     // clang-format on
 };
 
@@ -200,29 +200,29 @@ struct SSERegister<int64_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const int64_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const int64_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister broadcast     (int64_t x)         { return { _mm_set1_epi64x (x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const int64_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const int64_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister broadcast     (int64_t x)         { return { _mm_set1_epi64x (x) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("sse4.1") void storeUnaligned (int64_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
-    VCTR_TARGET ("sse4.1") void storeAligned (int64_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeUnaligned (int64_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeAligned (int64_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
-    VCTR_TARGET ("sse4.1") static SSERegister bitwiseAnd (SSERegister a, SSERegister b) { return { _mm_castpd_si128 (_mm_and_pd (_mm_castsi128_pd (a.value), _mm_castsi128_pd (b.value))) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister bitwiseOr (SSERegister a, SSERegister b) { return { _mm_castpd_si128 (_mm_or_pd (_mm_castsi128_pd (a.value), _mm_castsi128_pd (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister bitwiseAnd (SSERegister a, SSERegister b) { return { _mm_castpd_si128 (_mm_and_pd (_mm_castsi128_pd (a.value), _mm_castsi128_pd (b.value))) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister bitwiseOr (SSERegister a, SSERegister b) { return { _mm_castpd_si128 (_mm_or_pd (_mm_castsi128_pd (a.value), _mm_castsi128_pd (b.value))) }; }
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi64 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi64 (a.value, b.value) }; }
 
     //==============================================================================
     // Type conversion
-    VCTR_TARGET ("sse4.1") static SSERegister<double> convertToFp (SSERegister x)     { return { _mm_cvtepi64_pd (x.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister<double> reinterpretAsFp (SSERegister x) { return { _mm_castsi128_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<double> convertToFp (SSERegister x)     { return { _mm_cvtepi64_pd (x.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister<double> reinterpretAsFp (SSERegister x) { return { _mm_castsi128_pd (x.value) }; }
     // clang-format on
 };
 
@@ -237,22 +237,22 @@ struct SSERegister<uint64_t>
     //==============================================================================
     // Loading
     // clang-format off
-    VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const uint64_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const uint64_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister broadcast     (uint64_t x)         { return { _mm_set1_epi64x ((int64_t) x) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadUnaligned (const uint64_t* d)  { return { _mm_loadu_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister loadAligned   (const uint64_t* d)  { return { _mm_load_si128 (reinterpret_cast<const __m128i*> (d)) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister broadcast     (uint64_t x)         { return { _mm_set1_epi64x ((int64_t) x) }; }
 
     //==============================================================================
     // Storing
-    VCTR_TARGET ("sse4.1") void storeUnaligned (uint64_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
-    VCTR_TARGET ("sse4.1") void storeAligned (uint64_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeUnaligned (uint64_t* d) const { _mm_storeu_si128 (reinterpret_cast<__m128i*> (d), value); }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") void storeAligned (uint64_t* d)   const { _mm_store_si128 (reinterpret_cast<__m128i*> (d), value); }
 
     //==============================================================================
     // Bit Operations
 
     //==============================================================================
     // Math
-    VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi64 (a.value, b.value) }; }
-    VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister add (SSERegister a, SSERegister b) { return { _mm_add_epi64 (a.value, b.value) }; }
+    VCTR_FORCEDINLINE VCTR_TARGET ("sse4.1") static SSERegister sub (SSERegister a, SSERegister b) { return { _mm_sub_epi64 (a.value, b.value) }; }
     // clang-format on
 };
 

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -204,6 +204,7 @@ VCTR_END_IGNORE_WARNING_MSVC
 #include "Expressions/Trigonometric/Atanh.h"
 
 #include "Expressions/DSP/FastExp.h"
+#include "Expressions/DSP/FastLog.h"
 #include "Expressions/DSP/Decibels.h"
 
 #include "Generators/Linspace.h"

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -141,6 +141,7 @@ VCTR_END_IGNORE_WARNING_MSVC
 
 #include "Miscellaneous/Range.h"
 #include "Miscellaneous/StdRatioHelpers.h"
+#include "Miscellaneous/BitCast.h"
 
 #include "Containers/VctrBase.h"
 #include "Containers/Span.h"

--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -203,8 +203,8 @@ VCTR_END_IGNORE_WARNING_MSVC
 #include "Expressions/Trigonometric/Acosh.h"
 #include "Expressions/Trigonometric/Atanh.h"
 
-#include "Expressions/DSP/Decibels.h"
 #include "Expressions/DSP/FastExp.h"
+#include "Expressions/DSP/Decibels.h"
 
 #include "Generators/Linspace.h"
 

--- a/test/TestCases/BitwiseMaskOperations.cpp
+++ b/test/TestCases/BitwiseMaskOperations.cpp
@@ -73,15 +73,19 @@ struct CompareOpHelper<std::not_equal_to<T>>
 #if VCTR_ARM
 template <class T>
 using RegisterType = vctr::NeonRegister<T>;
-#else
+#elif VCTR_X64
 template <class T>
 using RegisterType = vctr::AVXRegister<T>;
-#if VCTR_GCC
+
 // In contrast to other test cases where we test higher level VCTR functions, we call register member functions directly here.
 // All the AVX functions are attributed with __attribute__ ((target ("avx"))). Directly taking the return value of those functions
-// here leads to issues with GCC obviously not using the correct calling conventions when compiling the test case without explicitly
-// setting the AVX target. This pragma enables it for the entire translation unit
+// here leads to issues with GCC/clang obviously not using the correct calling conventions when compiling the test case without
+// explicitly setting the AVX target. This pragma enables it for the entire translation unit
+#if VCTR_GCC
 #pragma GCC target ("avx")
+#endif
+#if VCTR_CLANG
+#pragma clang attribute push (__attribute__((target("avx"))), apply_to=function)
 #endif
 #endif
 
@@ -158,3 +162,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("BitwiseMaskOperations", "[VCTR][RegisterTypes][Bitw
         }
     }
 }
+
+#if VCTR_X64 && VCTR_CLANG
+#pragma clang attribute pop
+#endif

--- a/test/TestCases/Expressions/Decibels.cpp
+++ b/test/TestCases/Expressions/Decibels.cpp
@@ -62,3 +62,37 @@ TEMPLATE_PRODUCT_TEST_CASE ("Decibels", "[VCTR][Decibels]", (PlatformVectorOps, 
 
     // clang-format on
 }
+
+TEMPLATE_PRODUCT_TEST_CASE ("Fast decibel approximations", "[VCTR][Decibels]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )
+{
+    VCTR_TEST_DEFINES_WITH_TRAILING_ZERO_IN_RANGE (0, 2, 10)
+
+    // clang-format off
+    const vctr::Vector dBFS     = filter << vctr::fastMagToDb<vctr::dBFS> << srcD;
+    const vctr::Vector dBFSU    = filter << vctr::fastMagToDb<vctr::dBFS> << srcUnaligned;
+    const vctr::Vector dBPower  = filter << vctr::fastMagToDb<vctr::dBPower> << srcD;
+    const vctr::Vector dBPowerU = filter << vctr::fastMagToDb<vctr::dBPower> << srcUnaligned;
+
+    REQUIRE_THAT (dBFS,     vctr::EqualsTransformedBy<magToDbFS> (srcD).withEpsilon (0.005));
+    REQUIRE_THAT (dBFSU,    vctr::EqualsTransformedBy<magToDbFS> (srcUnaligned).withEpsilon (0.005));
+    REQUIRE_THAT (dBPower,  vctr::EqualsTransformedBy<magToDbPower> (srcD).withEpsilon (0.005));
+    REQUIRE_THAT (dBPowerU, vctr::EqualsTransformedBy<magToDbPower> (srcUnaligned).withEpsilon (0.005));
+
+    // The last source element is a magnitude of 0. This should result in the default minimum dB value which is -100
+    REQUIRE (dBFS[9]     == ElementType (-100));
+    REQUIRE (dBFSU[8]    == ElementType (-100));
+    REQUIRE (dBPower[9]  == ElementType (-100));
+    REQUIRE (dBPowerU[8] == ElementType (-100));
+    // clang-format on
+
+    // Transforming back to linear values should result in the original values
+    const vctr::Vector magFS     = filter << vctr::fastDbToMag<vctr::dBFS> << dBFS;
+    const vctr::Vector magFSU    = filter << vctr::fastDbToMag<vctr::dBFS> << dBFS.template subSpan<1>();
+    const vctr::Vector magPower  = filter << vctr::fastDbToMag<vctr::dBPower> << dBPower;
+    const vctr::Vector magPowerU = filter << vctr::fastDbToMag<vctr::dBPower> << dBPower.template subSpan<1>();
+
+    REQUIRE_THAT (magFS,     vctr::Equals (srcD).withMargin (0.005));
+    REQUIRE_THAT (magFSU,    vctr::Equals (srcUnaligned).withMargin (0.005));
+    REQUIRE_THAT (magPower,  vctr::Equals (srcD).withMargin (0.005));
+    REQUIRE_THAT (magPowerU, vctr::Equals (srcUnaligned).withMargin (0.005));
+}

--- a/test/TestCases/Expressions/Decibels.cpp
+++ b/test/TestCases/Expressions/Decibels.cpp
@@ -20,6 +20,7 @@
   ==============================================================================
 */
 
+#include <catch2/benchmark/catch_benchmark.hpp>
 #include <vctr_test_utils/vctr_test_common.h>
 
 // clang-format off

--- a/test/TestCases/Expressions/FastExp.cpp
+++ b/test/TestCases/Expressions/FastExp.cpp
@@ -28,6 +28,9 @@ T stdExp (T v) { return std::exp (v); }
 template <vctr::is::realFloatNumber T>
 T stdExp2 (T v) { return std::exp2 (v); }
 
+template <vctr::is::realFloatNumber T>
+T stdLog2 (T v) { return std::log2 (v); }
+
 template <vctr::is::realOrComplexFloatNumber T>
 T fastExp (T v) { return (T (1680) + v * (T (840) + v * (T (180) + v * (T (20) + v)))) / (T (1680) + v * (T (-840) + v * (T (180) + v * (T (-20) + v)))); }
 
@@ -66,4 +69,15 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp2 vs. StdExp2", "[VCTR][expressions][fastExp
 
     CHECK_THAT (res, vctr::EqualsTransformedBy<stdExp2> (srcA).withEpsilon (5.04e-5));
     CHECK_THAT (resU, vctr::EqualsTransformedBy<stdExp2> (srcUnaligned).withEpsilon (5.04e-5));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE ("FastLog2 vs. StdLog2", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )
+{
+    VCTR_TEST_DEFINES_IN_RANGE (0, 126, 10)
+
+    const vctr::Vector res = filter << vctr::fastLog2 << srcA;
+    const vctr::Vector resU = filter << vctr::fastLog2 << srcUnaligned;
+
+    CHECK_THAT (res, vctr::EqualsTransformedBy<stdLog2> (srcA).withEpsilon (2.0e-2));
+    CHECK_THAT (resU, vctr::EqualsTransformedBy<stdLog2> (srcUnaligned).withEpsilon (2.0e-2));
 }

--- a/test/TestCases/Expressions/FastExp.cpp
+++ b/test/TestCases/Expressions/FastExp.cpp
@@ -25,6 +25,9 @@
 template <vctr::is::realOrComplexFloatNumber T>
 T stdExp (T v) { return std::exp (v); }
 
+template <vctr::is::realFloatNumber T>
+T stdExp2 (T v) { return std::exp2 (v); }
+
 template <vctr::is::realOrComplexFloatNumber T>
 T fastExp (T v) { return (T (1680) + v * (T (840) + v * (T (180) + v * (T (20) + v)))) / (T (1680) + v * (T (-840) + v * (T (180) + v * (T (-20) + v)))); }
 
@@ -49,4 +52,18 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. StdExp", "[VCTR][expressions][fastExp]"
 
     REQUIRE_THAT (res, vctr::EqualsTransformedBy<stdExp> (srcA).withMargin (0.01));
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<stdExp> (srcUnaligned).withMargin (0.01));
+}
+
+TEMPLATE_PRODUCT_TEST_CASE ("FastExp2 vs. StdExp2", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+{
+    constexpr auto startValue = int (vctr::expressions::detail::FastExp2Constants<typename TestType::ElementType>::minExpo);
+    constexpr auto endValue = int (vctr::expressions::detail::FastExp2Constants<typename TestType::ElementType>::expoBias) + 1;
+
+    VCTR_TEST_DEFINES_IN_RANGE (startValue, endValue, 10)
+
+    const vctr::Vector res = filter << vctr::fastExp2 << srcA;
+    const vctr::Vector resU = filter << vctr::fastExp2 << srcUnaligned;
+
+    CHECK_THAT (res, vctr::EqualsTransformedBy<stdExp2> (srcA).withEpsilon (5.04e-5));
+    CHECK_THAT (resU, vctr::EqualsTransformedBy<stdExp2> (srcUnaligned).withEpsilon (5.04e-5));
 }

--- a/test/include/vctr_test_utils/Matchers/EqualsTransformedBy.h
+++ b/test/include/vctr_test_utils/Matchers/EqualsTransformedBy.h
@@ -110,7 +110,7 @@ struct UnaryEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBase
         std::transform (reference.begin(), reference.end(), refResult.begin(), transformingFn);
 
         std::ostringstream os;
-        os << "Equals: " << vctr::functionName<RetValueType, SrcValueType, transformingFn>() << " (" << reference << ") = " << refResult;
+        os << "\nEquals: " << vctr::functionName<RetValueType, SrcValueType, transformingFn>() << " (" << reference << ")\n = " << refResult;
         return os.str();
     }
 
@@ -166,8 +166,8 @@ struct BinaryEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBase
         std::transform (referenceA.begin(), referenceA.end(), referenceB.begin(), refResult.begin(), transformingFn);
 
         std::ostringstream os;
-        os << "Equals: " << vctr::functionName<RetValueType, SrcValueType, SrcValueType, transformingFn>() << " (" << referenceA
-           << ", " << referenceB << ") = " << refResult;
+        os << "\nEquals: " << vctr::functionName<RetValueType, SrcValueType, SrcValueType, transformingFn>() << " (" << referenceA
+           << ", " << referenceB << ")\n = " << refResult;
         return os.str();
     }
 
@@ -231,14 +231,14 @@ struct BinaryScalarEqualsTransformedMatcher : Catch::Matchers::MatcherGenericBas
         std::transform (referenceVec.begin(), referenceVec.end(), refResult.begin(), fnWithBoundScalar);
 
         std::ostringstream os;
-        os << "Equals: " << vctr::functionName<ValueType, ValueType, ValueType, transformingFn>() << " (";
+        os << "\nEquals: " << vctr::functionName<ValueType, ValueType, ValueType, transformingFn>() << " (";
 
         if (scalarBeforeVec)
             os << referenceScalar << ", " << referenceVec;
         else
             os << referenceVec << ", " << referenceScalar;
 
-        os << ") = " << refResult;
+        os << ")\n = " << refResult;
 
         return os.str();
     }


### PR DESCRIPTION
This ended up to be quite a lot of work, but it seems worth it. When compiling with clang, speedups are something between factor 10 to factor 5, depending on the platform. With MSVC I experienced at least a speedup of factor 2. This takes me to the conclusion that
a) a general compiler switch to clang on Windows might really be a good idea in general
b) we should add an extensive benchmark suite to this project finally
c) we should investigate why code generated with MSVC performs that worse compared with code generated with clang