### PR TITLE
vctr.h: Fix wrong license declaration in JUCE module section of the header

### DIFF
--- a/include/vctr/vctr.h
+++ b/include/vctr/vctr.h
@@ -32,7 +32,7 @@
   name:               VCTR
   description:        A powerful C++ 20 wrapper around your favourite standard library containers.
   website:            https://github.com/sonible/vctr
-  license:            MIT
+  license:            LGPLv3
   minimumCppStandard: 20
   dependencies:
   OSXFrameworks:      Accelerate


### PR DESCRIPTION
Just stumbled across this inconsistency. Another goal of this PR is to check if the documentation is uploaded again to GH pages, since I changed some settings that hopefully make GitHub picking up the next changes pushed to the docu branch again.