### PR TITLE
Spurious test fails: increase margins

### DIFF
--- a/test/TestCases/Expressions/Abs.cpp
+++ b/test/TestCases/Expressions/Abs.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("Abs", "[VCTR][abs]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Abs", "[VCTR][Expressions][abs]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Add.cpp
+++ b/test/TestCases/Expressions/Add.cpp
@@ -67,7 +67,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Addition in place", "[VCTR][add]", (PlatformVectorO
     // Todo: This causes build errors on some platforms. https://github.com/sonible/VCTR/issues/70
     //mac3 += vctr::multiplyByConstant<42> << srcB;
 
-    const auto eps = vctr::RealType<ElementType> (0.00001);
+    const auto eps = vctr::RealType<ElementType> (0.0001);
 
     for (size_t i = 0; i < 10; ++i)
     {

--- a/test/TestCases/Expressions/Add.cpp
+++ b/test/TestCases/Expressions/Add.cpp
@@ -25,7 +25,7 @@
 template <class T>
 T addition (T a, T b) { return a + b; }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Addition", "[VCTR][add]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Addition", "[VCTR][Expressions][add]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -42,7 +42,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Addition", "[VCTR][add]", (PlatformVectorOps, VCTR_
     REQUIRE_THAT (sum4, vctr::EqualsTransformedBy<addition> (srcA, ElementType (42)));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Addition in place", "[VCTR][add]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Addition in place", "[VCTR][Expressions][add]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Angle.cpp
+++ b/test/TestCases/Expressions/Angle.cpp
@@ -25,7 +25,7 @@
 template <std::floating_point T>
 T getAngle (std::complex<T> src) { return std::arg (src); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Angle", "[VCTR][complex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Angle", "[VCTR][Expressions][Complex][angle]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Clamp.cpp
+++ b/test/TestCases/Expressions/Clamp.cpp
@@ -34,7 +34,7 @@ auto clamp (T x) { return std::clamp (x, T (lo), T (hi)); }
 template <int bound, int factor, vctr::is::realNumber T>
 auto clampLowMultiply (T x) { return std::max (x, T (bound)) * T (factor); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("ClampLow", "[VCTR][clamp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("ClampLow", "[VCTR][Expressions][clamp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Conjugate.cpp
+++ b/test/TestCases/Expressions/Conjugate.cpp
@@ -25,7 +25,7 @@
 template <std::floating_point T>
 std::complex<T> conjugate (std::complex<T> v) { return std::conj (v); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Conjugate", "[VCTR][complex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Conjugate", "[VCTR][Expressions][Complex][conj]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Decibels.cpp
+++ b/test/TestCases/Expressions/Decibels.cpp
@@ -28,7 +28,7 @@ template <vctr::is::realFloatNumber T> auto magToDbFS    (T x) { return std::max
 template <vctr::is::realFloatNumber T> auto magToDbPower (T x) { return std::max (std::log10 (x) * T (10), T (-100)); }
 // clang-format on
 
-TEMPLATE_PRODUCT_TEST_CASE ("Decibels", "[VCTR][Decibels]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+TEMPLATE_PRODUCT_TEST_CASE ("Decibels", "[VCTR][Expressions][Decibels]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
 {
     VCTR_TEST_DEFINES_WITH_TRAILING_ZERO_IN_RANGE (0, 2, 10)
 
@@ -64,7 +64,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Decibels", "[VCTR][Decibels]", (PlatformVectorOps, 
     // clang-format on
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Fast decibel approximations", "[VCTR][Decibels]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )
+TEMPLATE_PRODUCT_TEST_CASE ("Fast decibel approximations", "[VCTR][Expressions][Decibels]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )
 {
     VCTR_TEST_DEFINES_WITH_TRAILING_ZERO_IN_RANGE (0, 2, 10)
 

--- a/test/TestCases/Expressions/Divide.cpp
+++ b/test/TestCases/Expressions/Divide.cpp
@@ -28,7 +28,7 @@
 #pragma warning(disable : 4146)
 #endif
 
-TEMPLATE_PRODUCT_TEST_CASE ("Division", "[VCTR][divide]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Division", "[VCTR][Expressions][divide]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_NO_ZEROS (10)
 

--- a/test/TestCases/Expressions/ElementwiseMax.cpp
+++ b/test/TestCases/Expressions/ElementwiseMax.cpp
@@ -23,7 +23,7 @@
 #include <vctr_test_utils/vctr_test_common.h>
 
 TEMPLATE_PRODUCT_TEST_CASE ("elementWiseMax",
-                            "[VCTR][elementWiseMax]",
+                            "[VCTR][Expressions][elementWiseMax]",
                             (PlatformVectorOps, VCTR_NATIVE_SIMD),
                             (float, double, int32_t, int64_t, uint32_t, uint64_t) )
 {

--- a/test/TestCases/Expressions/ElementwiseMin.cpp
+++ b/test/TestCases/Expressions/ElementwiseMin.cpp
@@ -23,7 +23,7 @@
 #include <vctr_test_utils/vctr_test_common.h>
 
 TEMPLATE_PRODUCT_TEST_CASE ("elementWiseMin",
-                            "[VCTR][elementWiseMin]",
+                            "[VCTR][Expressions][elementWiseMin]",
                             (PlatformVectorOps, VCTR_NATIVE_SIMD),
                             (float, double, int32_t, int64_t, uint32_t, uint64_t) )
 {

--- a/test/TestCases/Expressions/Exp.cpp
+++ b/test/TestCases/Expressions/Exp.cpp
@@ -33,7 +33,7 @@
 template <vctr::is::realNumber T>
 auto div10exp (T x) { return std::exp (x / T (10)); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Exp", "[VCTR][exp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
+TEMPLATE_PRODUCT_TEST_CASE ("Exp", "[VCTR][Expressions][exp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/FastExp.cpp
+++ b/test/TestCases/Expressions/FastExp.cpp
@@ -34,7 +34,7 @@ T stdLog2 (T v) { return std::log2 (v); }
 template <vctr::is::realOrComplexFloatNumber T>
 T fastExp (T v) { return (T (1680) + v * (T (840) + v * (T (180) + v * (T (20) + v)))) / (T (1680) + v * (T (-840) + v * (T (180) + v * (T (-20) + v)))); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. FastExp", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. FastExp", "[VCTR][Expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_IN_RANGE (-6, 4, 10)
 
@@ -45,7 +45,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. FastExp", "[VCTR][expressions][fastExp]
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<fastExp> (srcUnaligned).withEpsilon (1e-4));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. StdExp", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. StdExp", "[VCTR][Expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_IN_RANGE (-2, 2, 10)
 
@@ -56,7 +56,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. StdExp", "[VCTR][expressions][fastExp]"
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<stdExp> (srcUnaligned).withMargin (0.01));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("FastExp2 vs. StdExp2", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+TEMPLATE_PRODUCT_TEST_CASE ("FastExp2 vs. StdExp2", "[VCTR][Expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
 {
     constexpr auto startValue = int (vctr::expressions::detail::FastExp2Constants<typename TestType::ElementType>::minExpo);
     constexpr auto endValue = int (vctr::expressions::detail::FastExp2Constants<typename TestType::ElementType>::expoBias) + 1;
@@ -70,7 +70,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp2 vs. StdExp2", "[VCTR][expressions][fastExp
     CHECK_THAT (resU, vctr::EqualsTransformedBy<stdExp2> (srcUnaligned).withEpsilon (1e-4));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("FastLog2 vs. StdLog2", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )
+TEMPLATE_PRODUCT_TEST_CASE ("FastLog2 vs. StdLog2", "[VCTR][Expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )
 {
     VCTR_TEST_DEFINES_IN_RANGE (0, 126, 10)
 

--- a/test/TestCases/Expressions/FastExp.cpp
+++ b/test/TestCases/Expressions/FastExp.cpp
@@ -41,10 +41,9 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. FastExp", "[VCTR][expressions][fastExp]
     const vctr::Vector res = filter << vctr::fastExp << srcA;
     const vctr::Vector resU = filter << vctr::fastExp << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<fastExp> (srcA).withMargin (0.0001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<fastExp> (srcUnaligned).withMargin (0.0001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<fastExp> (srcA).withEpsilon (1e-4));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<fastExp> (srcUnaligned).withEpsilon (1e-4));
 }
-
 
 TEMPLATE_PRODUCT_TEST_CASE ("FastExp vs. StdExp", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
 {
@@ -67,8 +66,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("FastExp2 vs. StdExp2", "[VCTR][expressions][fastExp
     const vctr::Vector res = filter << vctr::fastExp2 << srcA;
     const vctr::Vector resU = filter << vctr::fastExp2 << srcUnaligned;
 
-    CHECK_THAT (res, vctr::EqualsTransformedBy<stdExp2> (srcA).withEpsilon (5.04e-5));
-    CHECK_THAT (resU, vctr::EqualsTransformedBy<stdExp2> (srcUnaligned).withEpsilon (5.04e-5));
+    CHECK_THAT (res, vctr::EqualsTransformedBy<stdExp2> (srcA).withEpsilon (1e-4));
+    CHECK_THAT (resU, vctr::EqualsTransformedBy<stdExp2> (srcUnaligned).withEpsilon (1e-4));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("FastLog2 vs. StdLog2", "[VCTR][expressions][fastExp]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float) )

--- a/test/TestCases/Expressions/Ln.cpp
+++ b/test/TestCases/Expressions/Ln.cpp
@@ -29,7 +29,7 @@ template <vctr::is::signedNumber T>      auto absLn (T x) { return std::log (std
 template <vctr::is::unsignedIntNumber T> auto absLn (T x) { return std::log (x); }
 // clang-format on
 
-TEMPLATE_PRODUCT_TEST_CASE ("Ln", "[VCTR][ln]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
+TEMPLATE_PRODUCT_TEST_CASE ("Ln", "[VCTR][Expressions][ln]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Log10.cpp
+++ b/test/TestCases/Expressions/Log10.cpp
@@ -29,7 +29,7 @@ template <vctr::is::signedNumber T>      auto absLog10 (T x) { return std::log10
 template <vctr::is::unsignedIntNumber T> auto absLog10 (T x) { return std::log10 (x); }
 // clang-format on
 
-TEMPLATE_PRODUCT_TEST_CASE ("Log10", "[VCTR][log10]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
+TEMPLATE_PRODUCT_TEST_CASE ("Log10", "[VCTR][Expressions][log10]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Log2.cpp
+++ b/test/TestCases/Expressions/Log2.cpp
@@ -29,7 +29,7 @@ template <vctr::is::signedNumber T>      auto absLog2 (T x) { return std::log2 (
 template <vctr::is::unsignedIntNumber T> auto absLog2 (T x) { return std::log2 (x); }
 // clang-format on
 
-TEMPLATE_PRODUCT_TEST_CASE ("Log2", "[VCTR][log2]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
+TEMPLATE_PRODUCT_TEST_CASE ("Log2", "[VCTR][Expressions][log2]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t))
 {
     VCTR_TEST_DEFINES (2)
 

--- a/test/TestCases/Expressions/Map.cpp
+++ b/test/TestCases/Expressions/Map.cpp
@@ -40,7 +40,7 @@ T map (T val)
     return val;
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Map", "[VCTR][expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+TEMPLATE_PRODUCT_TEST_CASE ("Map", "[VCTR][Expressions][map]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
 {
     constexpr int srcValueMin = -52;
     constexpr int srcValueMax = 4000;
@@ -60,7 +60,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Map", "[VCTR][expressions]", (PlatformVectorOps, VC
     REQUIRE_THAT (mapped1, (vctr::EqualsTransformedBy<map<srcValueMin, srcValueMax, dstValueMin, dstValueMax>> (srcA).withEpsilon (0.0001)));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("MapFrom0To1", "[VCTR][expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+TEMPLATE_PRODUCT_TEST_CASE ("MapFrom0To1", "[VCTR][Expressions][mapFrom0To1]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
 {
     constexpr int srcValueMin = 0;
     constexpr int srcValueMax = 1;
@@ -80,7 +80,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("MapFrom0To1", "[VCTR][expressions]", (PlatformVecto
     REQUIRE_THAT (mapped1, (vctr::EqualsTransformedBy<map<srcValueMin, srcValueMax, dstValueMin, dstValueMax>> (srcA).withEpsilon (0.0001)));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("MapTo0To1", "[VCTR][expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+TEMPLATE_PRODUCT_TEST_CASE ("MapTo0To1", "[VCTR][Expressions][mapTo0To1]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
 {
     constexpr int srcValueMin = -52;
     constexpr int srcValueMax = 4000;

--- a/test/TestCases/Expressions/Max.cpp
+++ b/test/TestCases/Expressions/Max.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("Max", "[VCTR][max]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, uint32_t, uint64_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("Max", "[VCTR][Expressions][max]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, uint32_t, uint64_t) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Mean.cpp
+++ b/test/TestCases/Expressions/Mean.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("Mean", "[VCTR][mean]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>, int32_t, int64_t, uint32_t, uint64_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("Mean", "[VCTR][Expressions][mean]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>, int32_t, int64_t, uint32_t, uint64_t) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -58,7 +58,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Mean", "[VCTR][mean]", (PlatformVectorOps, VCTR_NAT
     }
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("MeanSquare", "[VCTR][meanSquare]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>, int32_t, int64_t, uint32_t, uint64_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("MeanSquare", "[VCTR][Expressions][meanSquare]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>, int32_t, int64_t, uint32_t, uint64_t) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -97,7 +97,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("MeanSquare", "[VCTR][meanSquare]", (PlatformVectorO
     }
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("RMS", "[VCTR][rms]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("RMS", "[VCTR][Expressions][rms]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Mean.cpp
+++ b/test/TestCases/Expressions/Mean.cpp
@@ -72,7 +72,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("MeanSquare", "[VCTR][Expressions][meanSquare]", (Pl
     const auto ref = std::reduce (srcASquared.begin(), srcASquared.end()) / ElementType (vctr::RealType<ElementType> (srcASquared.size()));
     const auto refU = std::reduce (srcUSquared.begin(), srcUSquared.end()) / ElementType (vctr::RealType<ElementType> (srcUSquared.size()));
 
-    const auto eps = vctr::RealType<ElementType> (0.00002);
+    const auto eps = vctr::RealType<ElementType> (0.0001);
 
     if constexpr (vctr::is::complexFloatNumber<ElementType>)
     {

--- a/test/TestCases/Expressions/Min.cpp
+++ b/test/TestCases/Expressions/Min.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("Min", "[VCTR][min]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, uint32_t, uint64_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("Min", "[VCTR][Expressions][min]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, uint32_t, uint64_t) )
 {
     VCTR_TEST_DEFINES (10)
     constexpr auto srcOnlyNeg = UnitTestValues<ElementType>::template array<10, 0, -1000, -1>();

--- a/test/TestCases/Expressions/Multiply.cpp
+++ b/test/TestCases/Expressions/Multiply.cpp
@@ -25,7 +25,7 @@
 template <class T>
 T multiplication (T a, T b) { return a * b; }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Multiply", "[VCTR][multiply]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Multiply", "[VCTR][Expressions][multiply]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -42,7 +42,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Multiply", "[VCTR][multiply]", (PlatformVectorOps, 
     REQUIRE_THAT (product4, vctr::EqualsTransformedBy<multiplication> (srcA, ElementType (-2)).withEpsilon());
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Multiply in place", "[VCTR][multiply]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Multiply in place", "[VCTR][Expressions][multiply]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/MultiplyAccumulate.cpp
+++ b/test/TestCases/Expressions/MultiplyAccumulate.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("MultiplyAccumulate", "[VCTR][multiplyAccumulate]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+TEMPLATE_PRODUCT_TEST_CASE ("MultiplyAccumulate", "[VCTR][Expressions][multiplyAccumulate]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -35,7 +35,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("MultiplyAccumulate", "[VCTR][multiplyAccumulate]", 
     REQUIRE_THAT (x, vctr::Equals (xElementWise).withEpsilon (0.0001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("MultiplySubtract", "[VCTR][multiplyAccumulate]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+TEMPLATE_PRODUCT_TEST_CASE ("MultiplySubtract", "[VCTR][Expressions][multiplyAccumulate]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/NormalizeSum.cpp
+++ b/test/TestCases/Expressions/NormalizeSum.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("NormalizeSum", "[VCTR][expressions]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
+TEMPLATE_PRODUCT_TEST_CASE ("NormalizeSum", "[VCTR][Expressions][normalizeSum]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double))
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Pow.cpp
+++ b/test/TestCases/Expressions/Pow.cpp
@@ -46,7 +46,7 @@ template <int32_t exp> std::complex<float>  powerConstantExp (std::complex<float
 template <int32_t exp> std::complex<double> powerConstantExp (std::complex<double> base) { return std::pow (base, std::complex<double> (exp)); }
 // clang-format on
 
-TEMPLATE_PRODUCT_TEST_CASE ("Pow", "[VCTR][pow]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Pow", "[VCTR][Expressions][pow]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (0, 15, 10)
 

--- a/test/TestCases/Expressions/PowerSpectrum.cpp
+++ b/test/TestCases/Expressions/PowerSpectrum.cpp
@@ -25,7 +25,7 @@
 template <std::floating_point T>
 T getPowerSpectrum (std::complex<T> src) { return src.real() * src.real() + src.imag() * src.imag(); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("PowerSpectrum", "[VCTR][complex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("PowerSpectrum", "[VCTR][Expressions][Complex][powerSpectrum]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/RealImag.cpp
+++ b/test/TestCases/Expressions/RealImag.cpp
@@ -28,7 +28,7 @@ T getRealPart (std::complex<T> src) { return src.real(); }
 template <std::floating_point T>
 T getImagPart (std::complex<T> src) { return src.imag(); }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Real", "[VCTR][complex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Real", "[VCTR][Expressions][Complex][real]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -44,7 +44,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Real", "[VCTR][complex]", (PlatformVectorOps, VCTR_
     REQUIRE_THAT (realU, vctr::EqualsTransformedBy<getRealPart> (srcUnaligned));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Imag", "[VCTR][complex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Imag", "[VCTR][Expressions][Complex][imag]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -60,7 +60,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Imag", "[VCTR][complex]", (PlatformVectorOps, VCTR_
     REQUIRE_THAT (imagU, vctr::EqualsTransformedBy<getImagPart> (srcUnaligned));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("RealToComplex", "[VCTR][complex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
+TEMPLATE_PRODUCT_TEST_CASE ("RealToComplex", "[VCTR][Expressions][Complex][realToComplex]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/SIMDFilter.cpp
+++ b/test/TestCases/Expressions/SIMDFilter.cpp
@@ -25,7 +25,7 @@
 template <class T>
 T addition (T a, T b) { return a + b; }
 
-TEMPLATE_PRODUCT_TEST_CASE ("SIMDFilter", "[VCTR][SIMD]", (AnySIMD), (float, double, int32_t, uint32_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("SIMDFilter", "[VCTR][Expressions][SIMD]", (AnySIMD), (float, double, int32_t, uint32_t) )
 {
     VCTR_TEST_DEFINES (10)
     const vctr::Vector sum = vctr::assertSIMD << filter << (srcA + srcB);

--- a/test/TestCases/Expressions/SquareCube.cpp
+++ b/test/TestCases/Expressions/SquareCube.cpp
@@ -34,7 +34,7 @@ T square (T x) { return x * x; }
 template <class T>
 T cube (T x) { return x * x * x; }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Square Root", "[VCTR][sqrt]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Square Root", "[VCTR][Expressions][sqrt]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_IN_RANGE (0, 10000, 10)
 
@@ -43,7 +43,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Square Root", "[VCTR][sqrt]", (PlatformVectorOps, V
     REQUIRE_THAT (s, vctr::EqualsTransformedBy<sqrt> (srcA).withEpsilon (0.000001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Square", "[VCTR][square]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Square", "[VCTR][Expressions][square]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES_IN_RANGE (-20, 20, 10)
 
@@ -52,7 +52,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Square", "[VCTR][square]", (PlatformVectorOps, VCTR
     REQUIRE_THAT (s, vctr::EqualsTransformedBy<square> (srcA));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Cube", "[VCTR][cube]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Cube", "[VCTR][Expressions][cube]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Subtract.cpp
+++ b/test/TestCases/Expressions/Subtract.cpp
@@ -25,7 +25,7 @@
 template <class T>
 T subtraction (T a, T b) { return a - b; }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Subtraction", "[VCTR][subtract]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Subtraction", "[VCTR][Expressions][subtract]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -40,7 +40,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Subtraction", "[VCTR][subtract]", (PlatformVectorOp
     REQUIRE_THAT (vecMinusVec, vctr::EqualsTransformedBy<subtraction> (srcA, srcB));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Subtraction in place", "[VCTR][subtract]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
+TEMPLATE_PRODUCT_TEST_CASE ("Subtraction in place", "[VCTR][Expressions][subtract]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, uint32_t, int64_t, uint64_t, std::complex<float>, std::complex<double>) )
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Sum.cpp
+++ b/test/TestCases/Expressions/Sum.cpp
@@ -22,7 +22,7 @@
 
 #include <vctr_test_utils/vctr_test_common.h>
 
-TEMPLATE_PRODUCT_TEST_CASE ("Sum", "[VCTR][sum]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>, int32_t, int64_t, uint32_t, uint64_t) )
+TEMPLATE_PRODUCT_TEST_CASE ("Sum", "[VCTR][Expressions][sum]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>, int32_t, int64_t, uint32_t, uint64_t) )
 {
     VCTR_TEST_DEFINES (10)
 
@@ -58,7 +58,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sum", "[VCTR][sum]", (PlatformVectorOps, VCTR_NATIV
     }
 }
 
-TEST_CASE ("Sum strings", "[VCTR][sum]")
+TEST_CASE ("Sum strings", "[VCTR][Expressions][sum]")
 {
     const auto loremIpsum = UnitTestValues<std::string>::template array<10, 0>();
 

--- a/test/TestCases/Expressions/Transformation.cpp
+++ b/test/TestCases/Expressions/Transformation.cpp
@@ -31,7 +31,7 @@ double toDoublePlus1 (T in) { return static_cast<double> (in + T (1)); }
 template <vctr::is::realNumber T>
 std::string toStringPlus1 (T in) { return std::to_string (in + T (1)); }
 
-TEST_CASE ("TransformedByDynamicCast", "[VCTR][transformation]")
+TEST_CASE ("TransformedByDynamicCast", "[VCTR][Expressions][transformation]")
 {
     struct A
     {
@@ -76,7 +76,7 @@ TEST_CASE ("TransformedByDynamicCast", "[VCTR][transformation]")
     bs.forEach ([] (B* b) { delete b; });
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("TransformedByStaticCast", "[VCTR][transformation]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int16_t, int32_t, int64_t))
+TEMPLATE_PRODUCT_TEST_CASE ("TransformedByStaticCast", "[VCTR][Expressions][transformation]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int16_t, int32_t, int64_t))
 {
     VCTR_TEST_DEFINES (10)
 
@@ -88,7 +88,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("TransformedByStaticCast", "[VCTR][transformation]",
     REQUIRE_THAT (castedToDouble, vctr::EqualsTransformedBy<toDoublePlus1> (srcA));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("TransformedBy", "[VCTR][transformation]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t))
+TEMPLATE_PRODUCT_TEST_CASE ("TransformedBy", "[VCTR][Expressions][transformation]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, int32_t, int64_t))
 {
     VCTR_TEST_DEFINES (10)
 

--- a/test/TestCases/Expressions/Trigonometric.cpp
+++ b/test/TestCases/Expressions/Trigonometric.cpp
@@ -58,6 +58,8 @@ T acosh (T v) { return std::acosh (v); }
 template <vctr::is::realOrComplexFloatNumber T>
 T atanh (T v) { return std::atanh (v); }
 
+static constexpr auto trigonometricTestMargin = 0.0001;
+
 
 TEMPLATE_PRODUCT_TEST_CASE ("Sin", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
@@ -66,8 +68,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sin", "[VCTR][Expressions][trigonometric]", (Platfo
     const vctr::Vector res = filter << vctr::sin << srcA;
     const vctr::Vector resU = filter << vctr::sin << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<sin> (srcA).withMargin (0.0001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<sin> (srcUnaligned).withMargin (0.0001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<sin> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<sin> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Cos", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -77,8 +79,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Cos", "[VCTR][Expressions][trigonometric]", (Platfo
     const vctr::Vector res = filter << vctr::cos << srcA;
     const vctr::Vector resU = filter << vctr::cos << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<cos> (srcA).withMargin (0.0001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<cos> (srcUnaligned).withMargin (0.0001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<cos> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<cos> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Tan", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -88,8 +90,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Tan", "[VCTR][Expressions][trigonometric]", (Platfo
     const vctr::Vector res = filter << vctr::tan << srcA;
     const vctr::Vector resU = filter << vctr::tan << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<tan> (srcA).withMargin (0.0001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<tan> (srcUnaligned).withMargin (0.0001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<tan> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<tan> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Sinh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -99,8 +101,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sinh", "[VCTR][Expressions][trigonometric]", (Platf
     const vctr::Vector res = filter << vctr::sinh << srcA;
     const vctr::Vector resU = filter << vctr::sinh << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<sinh> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<sinh> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<sinh> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<sinh> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Cosh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -110,8 +112,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Cosh", "[VCTR][Expressions][trigonometric]", (Platf
     const vctr::Vector res = filter << vctr::cosh << srcA;
     const vctr::Vector resU = filter << vctr::cosh << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<cosh> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<cosh> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<cosh> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<cosh> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Tanh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -121,8 +123,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Tanh", "[VCTR][Expressions][trigonometric]", (Platf
     const vctr::Vector res = filter << vctr::tanh << srcA;
     const vctr::Vector resU = filter << vctr::tanh << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<tanh> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<tanh> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<tanh> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<tanh> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Asin", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -132,8 +134,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Asin", "[VCTR][Expressions][trigonometric]", (Platf
     const vctr::Vector res = filter << vctr::asin << srcA;
     const vctr::Vector resU = filter << vctr::asin << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<asin> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<asin> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<asin> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<asin> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Acos", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -143,8 +145,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Acos", "[VCTR][Expressions][trigonometric]", (Platf
     const vctr::Vector res = filter << vctr::acos << srcA;
     const vctr::Vector resU = filter << vctr::acos << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<acos> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<acos> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<acos> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<acos> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Atan", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -154,8 +156,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Atan", "[VCTR][Expressions][trigonometric]", (Platf
     const vctr::Vector res = filter << vctr::atan << srcA;
     const vctr::Vector resU = filter << vctr::atan << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<atan> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<atan> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<atan> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<atan> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Asinh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -165,8 +167,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Asinh", "[VCTR][Expressions][trigonometric]", (Plat
     const vctr::Vector res = filter << vctr::asinh << srcA;
     const vctr::Vector resU = filter << vctr::asinh << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<asinh> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<asinh> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<asinh> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<asinh> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Acosh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -176,8 +178,8 @@ TEMPLATE_PRODUCT_TEST_CASE ("Acosh", "[VCTR][Expressions][trigonometric]", (Plat
     const vctr::Vector res = filter << vctr::acosh << srcA;
     const vctr::Vector resU = filter << vctr::acosh << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<acosh> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<acosh> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<acosh> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<acosh> (srcUnaligned).withMargin (trigonometricTestMargin));
 }
 
 TEMPLATE_PRODUCT_TEST_CASE ("Atanh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
@@ -187,6 +189,6 @@ TEMPLATE_PRODUCT_TEST_CASE ("Atanh", "[VCTR][Expressions][trigonometric]", (Plat
     const vctr::Vector res = filter << vctr::atanh << srcA;
     const vctr::Vector resU = filter << vctr::atanh << srcUnaligned;
 
-    REQUIRE_THAT (res, vctr::EqualsTransformedBy<atanh> (srcA).withMargin (0.00001));
-    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<atanh> (srcUnaligned).withMargin (0.00001));
+    REQUIRE_THAT (res, vctr::EqualsTransformedBy<atanh> (srcA).withMargin (trigonometricTestMargin));
+    REQUIRE_THAT (resU, vctr::EqualsTransformedBy<atanh> (srcUnaligned).withMargin (trigonometricTestMargin));
 }

--- a/test/TestCases/Expressions/Trigonometric.cpp
+++ b/test/TestCases/Expressions/Trigonometric.cpp
@@ -59,7 +59,7 @@ template <vctr::is::realOrComplexFloatNumber T>
 T atanh (T v) { return std::atanh (v); }
 
 
-TEMPLATE_PRODUCT_TEST_CASE ("Sin", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Sin", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -70,7 +70,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sin", "[VCTR][expressions][trigonometric]", (Platfo
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<sin> (srcUnaligned).withMargin (0.0001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Cos", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Cos", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -81,7 +81,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Cos", "[VCTR][expressions][trigonometric]", (Platfo
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<cos> (srcUnaligned).withMargin (0.0001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Tan", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Tan", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -92,7 +92,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Tan", "[VCTR][expressions][trigonometric]", (Platfo
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<tan> (srcUnaligned).withMargin (0.0001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Sinh", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Sinh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -103,7 +103,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Sinh", "[VCTR][expressions][trigonometric]", (Platf
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<sinh> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Cosh", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Cosh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -114,7 +114,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Cosh", "[VCTR][expressions][trigonometric]", (Platf
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<cosh> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Tanh", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Tanh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -125,7 +125,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Tanh", "[VCTR][expressions][trigonometric]", (Platf
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<tanh> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Asin", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Asin", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-1, 1, 10)
 
@@ -136,7 +136,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Asin", "[VCTR][expressions][trigonometric]", (Platf
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<asin> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Acos", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Acos", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-1, 1, 10)
 
@@ -147,7 +147,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Acos", "[VCTR][expressions][trigonometric]", (Platf
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<acos> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Atan", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Atan", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -158,7 +158,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Atan", "[VCTR][expressions][trigonometric]", (Platf
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<atan> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Asinh", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Asinh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-4, 4, 10)
 
@@ -169,7 +169,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Asinh", "[VCTR][expressions][trigonometric]", (Plat
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<asinh> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Acosh", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Acosh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (1, 10, 10)
 
@@ -180,7 +180,7 @@ TEMPLATE_PRODUCT_TEST_CASE ("Acosh", "[VCTR][expressions][trigonometric]", (Plat
     REQUIRE_THAT (resU, vctr::EqualsTransformedBy<acosh> (srcUnaligned).withMargin (0.00001));
 }
 
-TEMPLATE_PRODUCT_TEST_CASE ("Atanh", "[VCTR][expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
+TEMPLATE_PRODUCT_TEST_CASE ("Atanh", "[VCTR][Expressions][trigonometric]", (PlatformVectorOps, VCTR_NATIVE_SIMD), (float, double, std::complex<float>, std::complex<double>))
 {
     VCTR_TEST_DEFINES_IN_RANGE (-1, 1, 10)
 


### PR DESCRIPTION
Review-ready now. I tested it with the following run config, using seeds that have provoked test failures in the past:

```
      - name: Run test (seeded for Add)
        run: ./build/test/TestMain/vctr_test --rng-seed 3043489734

      - name: Run test (seeded for fastExp)
        run: ./build/test/TestMain/vctr_test --rng-seed 1285096097

      - name: Run test (seeded for Decibels)
        run: ./build/test/TestMain/vctr_test --rng-seed 760312143

      - name: Run test (seeded for Mean)
        run: ./build/test/TestMain/vctr_test --rng-seed 1432506547
```